### PR TITLE
Support Web API

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -230,7 +230,7 @@ $sqlQuery->exec('memo_add', ['memo' => 'run', 'created_at' => new DateTime()]);
 
 オブジェクトが渡されるとParameter Injectionと同様`toScalar()`または`__toString()`の値に変換されます。
 
-
+#
 ## プロファイラー
 
 メディアアクセスはロガーで記録されます。標準ではテストに使うメモリロガーがバインドされています。

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,9 @@
         "ext-json": "*",
         "ext-pdo": "*",
         "aura/sql": "^3.0",
-        "pagerfanta/pagerfanta": "^1.1",
         "doctrine/annotations": "^1.11",
+        "guzzlehttp/guzzle": "^7.2",
+        "pagerfanta/pagerfanta": "^1.1",
         "ray/aop": "^2.10",
         "ray/aura-sql-module": "^1.10",
         "ray/di": "2.x-dev"

--- a/demo/run.php
+++ b/demo/run.php
@@ -29,7 +29,7 @@ $injector = new Injector(new class($sqlDir, $dsn) extends AbstractModule {
             UserAddInterface::class,
             UserItemInterface::class
         ]);
-        $this->install(new MediaQueryModule($this->sqlDir, $queries));
+        $this->install(new MediaQueryModule($queries, $this->sqlDir));
         $this->install(new AuraSqlModule($this->dsn));
     }
 });

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -49,6 +49,7 @@
         <exclude name="PSR12.Files.FileHeader.IncorrectOrder"/>
         <exclude name="PSR12.Files.FileHeader.SpacingAfterBlock"/>
         <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.UselessAnnotation"/>
     </rule>
 
 

--- a/src/Annotation/WebQuery.php
+++ b/src/Annotation/WebQuery.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery\Annotation;
+
+use Attribute;
+use Doctrine\Common\Annotations\NamedArgumentConstructorAnnotation;
+
+/**
+ * @Annotation
+ * @Target("METHOD")
+ */
+#[Attribute(Attribute::TARGET_METHOD)]
+final class WebQuery implements NamedArgumentConstructorAnnotation
+{
+    /** @var string */
+    public $method;
+
+    /** @var string */
+    public $uri;
+
+    public function __construct(string $method, string $uri)
+    {
+        $this->method = $method;
+        $this->uri = $uri;
+    }
+}

--- a/src/DbQueryInterceptor.php
+++ b/src/DbQueryInterceptor.php
@@ -11,7 +11,7 @@ use Ray\MediaQuery\Annotation\Pager;
 
 use function substr;
 
-class MediaQueryInterceptor implements MethodInterceptor
+class DbQueryInterceptor implements MethodInterceptor
 {
     /** @var SqlQueryInterface */
     private $sqlQuery;

--- a/src/Exception/WebApiRequestException.php
+++ b/src/Exception/WebApiRequestException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery\Exception;
+
+use RuntimeException;
+
+class WebApiRequestException extends RuntimeException
+{
+}

--- a/src/MediaQueryLogger.php
+++ b/src/MediaQueryLogger.php
@@ -24,7 +24,7 @@ final class MediaQueryLogger implements MediaQueryLoggerInterface
      */
     public function log(string $queryId, array $values): void
     {
-        $this->logs[] = sprintf('query:%s(%s)', $queryId, json_encode($values));
+        $this->logs[] = sprintf('query: %s(%s)', $queryId, json_encode($values));
     }
 
     public function __toString(): string

--- a/src/MediaQueryModule.php
+++ b/src/MediaQueryModule.php
@@ -6,10 +6,13 @@ namespace Ray\MediaQuery;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use Ray\Di\AbstractModule;
 use Ray\Di\Scope;
 use Ray\MediaQuery\Annotation\DbQuery;
 use Ray\MediaQuery\Annotation\SqlDir;
+use Ray\MediaQuery\Annotation\WebQuery;
 
 class MediaQueryModule extends AbstractModule
 {
@@ -28,20 +31,30 @@ class MediaQueryModule extends AbstractModule
 
     protected function configure(): void
     {
-        $this->bind(SqlQueryInterface::class)->to(SqlQuery::class);
         $this->bind(MediaQueryLoggerInterface::class)->to(MediaQueryLogger::class)->in(Scope::SINGLETON);
         $this->bind(ParamInjectorInterface::class)->to(ParamInjector::class);
         $this->bind(ParamConverterInterface::class)->to(ParamConverter::class);
         $this->bind(DateTimeInterface::class)->to(DateTimeImmutable::class);
+        // Bind media query interface
+        foreach ($this->mediaQueries as $mediaQuery) {
+            $this->bind($mediaQuery)->toNull();
+        }
+
+        // DbQuery
+        $this->bind(SqlQueryInterface::class)->to(SqlQuery::class);
         $this->bindInterceptor(
             $this->matcher->any(),
             $this->matcher->annotatedWith(DbQuery::class),
             [DbQueryInterceptor::class]
         );
         $this->bind()->annotatedWith(SqlDir::class)->toInstance($this->sqlDir);
-        // Bind media query interface
-        foreach ($this->mediaQueries as $mediaQuery) {
-            $this->bind($mediaQuery)->toNull();
-        }
+        // Web Query
+        $this->bindInterceptor(
+            $this->matcher->any(),
+            $this->matcher->annotatedWith(WebQuery::class),
+            [WebQueryInterceptor::class]
+        );
+        $this->bind(ClientInterface::class)->to(Client::class);
+        $this->bind(WebApiQueryInterface::class)->to(WebApiQuery::class);
     }
 }

--- a/src/MediaQueryModule.php
+++ b/src/MediaQueryModule.php
@@ -26,9 +26,12 @@ class MediaQueryModule extends AbstractModule
     private array $domainBindings;
 
     /**
+     * @param Queries               $mediaQueries
+     * @param string                $sqlDir
      * @param array<string, string> $domainBindings
+     * @param AbstractModule|null   $module
      */
-    public function __construct(string $sqlDir, Queries $mediaQueries, array $domainBindings, ?AbstractModule $module = null)
+    public function __construct(Queries $mediaQueries, string $sqlDir, array $domainBindings = [], ?AbstractModule $module = null)
     {
         $this->mediaQueries = $mediaQueries->classes;
         $this->sqlDir = $sqlDir;

--- a/src/MediaQueryModule.php
+++ b/src/MediaQueryModule.php
@@ -22,10 +22,17 @@ class MediaQueryModule extends AbstractModule
     /** @var list<class-string> */
     private $mediaQueries;
 
-    public function __construct(string $sqlDir, Queries $mediaQueries, ?AbstractModule $module = null)
+    /** @var array<string, string> */
+    private array $domainBindings;
+
+    /**
+     * @param array<string, string> $domainBindings
+     */
+    public function __construct(string $sqlDir, Queries $mediaQueries, array $domainBindings, ?AbstractModule $module = null)
     {
         $this->mediaQueries = $mediaQueries->classes;
         $this->sqlDir = $sqlDir;
+        $this->domainBindings = $domainBindings;
         parent::__construct($module);
     }
 
@@ -56,5 +63,6 @@ class MediaQueryModule extends AbstractModule
         );
         $this->bind(ClientInterface::class)->to(Client::class);
         $this->bind(WebApiQueryInterface::class)->to(WebApiQuery::class);
+        $this->bind()->annotatedWith('web_api_query_domain')->toInstance($this->domainBindings);
     }
 }

--- a/src/MediaQueryModule.php
+++ b/src/MediaQueryModule.php
@@ -36,7 +36,7 @@ class MediaQueryModule extends AbstractModule
         $this->bindInterceptor(
             $this->matcher->any(),
             $this->matcher->annotatedWith(DbQuery::class),
-            [MediaQueryInterceptor::class]
+            [DbQueryInterceptor::class]
         );
         $this->bind()->annotatedWith(SqlDir::class)->toInstance($this->sqlDir);
         // Bind media query interface

--- a/src/WebApiQuery.php
+++ b/src/WebApiQuery.php
@@ -6,6 +6,7 @@ namespace Ray\MediaQuery;
 
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
+use Ray\Di\Di\Named;
 use RuntimeException;
 
 use function json_decode;
@@ -16,15 +17,21 @@ final class WebApiQuery implements WebApiQueryInterface
     /** @var ClientInterface */
     private $client;
 
-    /**
-     * @var MediaQueryLoggerInterface
-     */
-    private MediaQueryLoggerInterface $logger;
+    /** @var MediaQueryLoggerInterface  */
+    private $logger;
 
-    public function __construct(ClientInterface $client, MediaQueryLoggerInterface $logger)
+    /** @var array<string, string>  */
+    private $domainBindings;
+
+    /**
+     * @param array<string, string> $domainBindings
+     */
+    #[Named('domainBindings=web_api_query_domain')]
+    public function __construct(ClientInterface $client, MediaQueryLoggerInterface $logger, array $domainBindings)
     {
         $this->client = $client;
         $this->logger = $logger;
+        $this->domainBindings = $domainBindings;
     }
 
     /**
@@ -34,12 +41,13 @@ final class WebApiQuery implements WebApiQueryInterface
     {
         try {
             $this->logger->start();
-            $boundUri = uri_template($uri, $query);
+            $boundUri = uri_template($uri, $this->domainBindings + $query);
             $response = $this->client->request($method, $boundUri, $query);
             $json = $response->getBody()->getContents();
             /** @var array<string, mixed> $body */
             $body = json_decode($json, true);
             $this->logger->log($boundUri, $query);
+
             return $body;
         } catch (GuzzleException $e) {
             throw new RuntimeException($e->getMessage(), 0, $e);

--- a/src/WebApiQuery.php
+++ b/src/WebApiQuery.php
@@ -25,6 +25,8 @@ final class WebApiQuery implements WebApiQueryInterface
 
     /**
      * @param array<string, string> $domainBindings
+     *
+     * @Named("'domainBindings=web_api_query_domain")
      */
     #[Named('domainBindings=web_api_query_domain')]
     public function __construct(ClientInterface $client, MediaQueryLoggerInterface $logger, array $domainBindings)

--- a/src/WebApiQuery.php
+++ b/src/WebApiQuery.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\GuzzleException;
+use RuntimeException;
+
+use function json_decode;
+use function uri_template;
+
+final class WebApiQuery implements WebApiQueryInterface
+{
+    /** @var ClientInterface */
+    private $client;
+
+    /**
+     * @var MediaQueryLoggerInterface
+     */
+    private MediaQueryLoggerInterface $logger;
+
+    public function __construct(ClientInterface $client, MediaQueryLoggerInterface $logger)
+    {
+        $this->client = $client;
+        $this->logger = $logger;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function request(string $method, string $uri, array $query): array
+    {
+        try {
+            $this->logger->start();
+            $boundUri = uri_template($uri, $query);
+            $response = $this->client->request($method, $boundUri, $query);
+            $json = $response->getBody()->getContents();
+            /** @var array<string, mixed> $body */
+            $body = json_decode($json, true);
+            $this->logger->log($boundUri, $query);
+            return $body;
+        } catch (GuzzleException $e) {
+            throw new RuntimeException($e->getMessage(), 0, $e);
+        }
+    }
+}

--- a/src/WebApiQuery.php
+++ b/src/WebApiQuery.php
@@ -7,7 +7,7 @@ namespace Ray\MediaQuery;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 use Ray\Di\Di\Named;
-use RuntimeException;
+use Ray\MediaQuery\Exception\WebApiRequestException;
 
 use function json_decode;
 use function uri_template;
@@ -52,7 +52,7 @@ final class WebApiQuery implements WebApiQueryInterface
 
             return $body;
         } catch (GuzzleException $e) {
-            throw new RuntimeException($e->getMessage(), 0, $e);
+            throw new WebApiRequestException($e->getMessage(), (int) $e->getCode(), $e);
         }
     }
 }

--- a/src/WebApiQueryInterface.php
+++ b/src/WebApiQueryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+
+interface WebApiQueryInterface
+{
+    /**
+     * @param array<string, string> $query
+     *
+     * @return array<string, mixed>
+     */
+    public function request(string $method, string $uri, array $query): array;
+}

--- a/src/WebQueryInterceptor.php
+++ b/src/WebQueryInterceptor.php
@@ -13,16 +13,12 @@ class WebQueryInterceptor implements MethodInterceptor
     /** @var WebApiQueryInterface */
     private $webApiQuery;
 
-    /** @var MediaQueryLoggerInterface */
-    private $logger;
-
     /** @var ParamInjectorInterface  */
     private $paramInjector;
 
-    public function __construct(WebApiQueryInterface $webApiQuery, MediaQueryLoggerInterface $logger, ParamInjectorInterface $paramInjector)
+    public function __construct(WebApiQueryInterface $webApiQuery, ParamInjectorInterface $paramInjector)
     {
         $this->webApiQuery = $webApiQuery;
-        $this->logger = $logger;
         $this->paramInjector = $paramInjector;
     }
 

--- a/src/WebQueryInterceptor.php
+++ b/src/WebQueryInterceptor.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+
+use Ray\Aop\MethodInterceptor;
+use Ray\Aop\MethodInvocation;
+use Ray\MediaQuery\Annotation\WebQuery;
+
+class WebQueryInterceptor implements MethodInterceptor
+{
+    /** @var WebApiQueryInterface */
+    private $webApiQuery;
+
+    /** @var MediaQueryLoggerInterface */
+    private $logger;
+
+    /** @var ParamInjectorInterface  */
+    private $paramInjector;
+
+    public function __construct(WebApiQueryInterface $webApiQuery, MediaQueryLoggerInterface $logger, ParamInjectorInterface $paramInjector)
+    {
+        $this->webApiQuery = $webApiQuery;
+        $this->logger = $logger;
+        $this->paramInjector = $paramInjector;
+    }
+
+    /**
+     * @return Pages|array<mixed>
+     */
+    public function invoke(MethodInvocation $invocation)
+    {
+        $method = $invocation->getMethod();
+        /** @var WebQuery $webQuery */
+        $webQuery = $method->getAnnotation(WebQuery::class);
+        /** @var array<string, string> $values */
+        $values = $this->paramInjector->getArgumentes($invocation);
+
+        return $this->webApiQuery->request($webQuery->method, $webQuery->uri, $values);
+    }
+}

--- a/tests/Fake/WebApi/FooItemInterface.php
+++ b/tests/Fake/WebApi/FooItemInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery\WebApi;
+
+use Ray\MediaQuery\Annotation\WebQuery;
+
+interface FooItemInterface
+{
+    #[WebQuery(method: 'GET', uri: 'https://httpbin.org/anything/{id}')]
+    public function __invoke(string $id): array;
+}

--- a/tests/Fake/WebApi/FooItemInterface.php
+++ b/tests/Fake/WebApi/FooItemInterface.php
@@ -8,6 +8,6 @@ use Ray\MediaQuery\Annotation\WebQuery;
 
 interface FooItemInterface
 {
-    #[WebQuery(method: 'GET', uri: 'https://httpbin.org/anything/{id}')]
+    #[WebQuery(method: 'GET', uri: 'https://{domain}/anything/{id}')]
     public function __invoke(string $id): array;
 }

--- a/tests/MediaQueryModuleTest.php
+++ b/tests/MediaQueryModuleTest.php
@@ -44,7 +44,7 @@ class MediaQueryModuleTest extends TestCase
             PromiseListInterface::class,
         ]);
         $sqlDir = dirname(__DIR__) . '/tests/sql';
-        $module = new MediaQueryModule($sqlDir, $mediaQueries, [], new AuraSqlModule('sqlite::memory:'));
+        $module = new MediaQueryModule($mediaQueries, $sqlDir, [], new AuraSqlModule('sqlite::memory:'));
         $this->injector = new Injector($module);
         $pdo = $this->injector->getInstance(ExtendedPdoInterface::class);
         assert($pdo instanceof ExtendedPdoInterface);

--- a/tests/MediaQueryModuleTest.php
+++ b/tests/MediaQueryModuleTest.php
@@ -44,7 +44,7 @@ class MediaQueryModuleTest extends TestCase
             PromiseListInterface::class,
         ]);
         $sqlDir = dirname(__DIR__) . '/tests/sql';
-        $module = new MediaQueryModule($sqlDir, $mediaQueries, new AuraSqlModule('sqlite::memory:'));
+        $module = new MediaQueryModule($sqlDir, $mediaQueries, [], new AuraSqlModule('sqlite::memory:'));
         $this->injector = new Injector($module);
         $pdo = $this->injector->getInstance(ExtendedPdoInterface::class);
         assert($pdo instanceof ExtendedPdoInterface);
@@ -63,14 +63,14 @@ class MediaQueryModuleTest extends TestCase
         assert($todoAdd instanceof TodoAddInterface);
         $todoAdd('1', 'run');
         $log = (string) $this->logger;
-        $this->assertStringContainsString('query:todo_add', $log);
+        $this->assertStringContainsString('query: todo_add', $log);
         $todoItem = $this->injector->getInstance(TodoItemInterface::class);
 
         assert($todoItem instanceof TodoItemInterface);
         $item = $todoItem('1');
         $this->assertSame(['id' => '1', 'title' => 'run'], $item);
         $log = (string) $this->logger;
-        $this->assertStringContainsString('query:todo_item', $log);
+        $this->assertStringContainsString('query: todo_item', $log);
     }
 
     public function testSelectItem(): void
@@ -80,7 +80,7 @@ class MediaQueryModuleTest extends TestCase
         $item = $todoItem('1');
         $this->assertSame(['id' => '1', 'title' => 'run'], $item);
         $log = (string) $this->logger;
-        $this->assertStringContainsString('query:todo_item', $log);
+        $this->assertStringContainsString('query: todo_item', $log);
     }
 
     public function testSelectList(): void
@@ -91,7 +91,7 @@ class MediaQueryModuleTest extends TestCase
         $row = ['id' => '1', 'title' => 'run', 'time' => '1970-01-01 00:00:00'];
         $this->assertSame([$row], $list);
         $log = (string) $this->logger;
-        $this->assertStringContainsString('query:promise_list([])', $log);
+        $this->assertStringContainsString('query: promise_list([])', $log);
     }
 
     public function testSelectPager(): void
@@ -103,7 +103,7 @@ class MediaQueryModuleTest extends TestCase
         $page = $list[1];
         $this->assertSame([['id' => '1', 'title' => 'run']], $page->data);
         $log = (string) $this->logger;
-        $this->assertStringContainsString('query:todo_list', $log);
+        $this->assertStringContainsString('query: todo_list', $log);
     }
 
     public function testPramInjection(): void

--- a/tests/SqlQueryTest.php
+++ b/tests/SqlQueryTest.php
@@ -55,7 +55,7 @@ class SqlQueryTest extends TestCase
     public function testExec(): void
     {
         $this->sqlQuery->exec('todo_add', $this->insertData);
-        $this->assertStringContainsString('query:todo_add({"id":"1","title":"run"})', (string) $this->log);
+        $this->assertStringContainsString('query: todo_add({"id":"1","title":"run"})', (string) $this->log);
     }
 
     /**

--- a/tests/WebQueryModuleTest.php
+++ b/tests/WebQueryModuleTest.php
@@ -27,7 +27,7 @@ class WebQueryModuleTest extends TestCase
         $mediaQueries = Queries::fromClasses([FooItemInterface::class]);
         $sqlDir = dirname(__DIR__) . '/tests/sql';
         $uriBindings = ['domain' => 'httpbin.org'];
-        $module = new MediaQueryModule($sqlDir, $mediaQueries, $uriBindings);
+        $module = new MediaQueryModule($mediaQueries, $sqlDir, $uriBindings);
         $this->injector = new Injector($module);
         $this->logger = $this->injector->getInstance(MediaQueryLoggerInterface::class);
     }

--- a/tests/WebQueryModuleTest.php
+++ b/tests/WebQueryModuleTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+
+use PHPUnit\Framework\TestCase;
+use Ray\Di\AbstractModule;
+use Ray\Di\Injector;
+use Ray\MediaQuery\WebApi\FooItemInterface;
+
+use function dirname;
+
+class WebQueryModuleTest extends TestCase
+{
+    /** @var AbstractModule */
+    protected $module;
+
+    /** @var MediaQueryLoggerInterface */
+    private $logger;
+
+    /** @var Injector */
+    private $injector;
+
+    protected function setUp(): void
+    {
+        $mediaQueries = Queries::fromClasses([FooItemInterface::class]);
+        $sqlDir = dirname(__DIR__) . '/tests/sql';
+        $module = new MediaQueryModule($sqlDir, $mediaQueries);
+        $this->injector = new Injector($module);
+        $this->logger = $this->injector->getInstance(MediaQueryLoggerInterface::class);
+    }
+
+    public function testGetRequest(): void
+    {
+        $fooItem = $this->injector->getInstance(FooItemInterface::class);
+        $response = ($fooItem)('hello');
+        $this->assertSame('https://httpbin.org/anything/hello', $response['url']);
+    }
+}

--- a/tests/WebQueryModuleTest.php
+++ b/tests/WebQueryModuleTest.php
@@ -26,7 +26,8 @@ class WebQueryModuleTest extends TestCase
     {
         $mediaQueries = Queries::fromClasses([FooItemInterface::class]);
         $sqlDir = dirname(__DIR__) . '/tests/sql';
-        $module = new MediaQueryModule($sqlDir, $mediaQueries);
+        $uriBindings = ['domain' => 'httpbin.org'];
+        $module = new MediaQueryModule($sqlDir, $mediaQueries, $uriBindings);
         $this->injector = new Injector($module);
         $this->logger = $this->injector->getInstance(MediaQueryLoggerInterface::class);
     }
@@ -36,5 +37,6 @@ class WebQueryModuleTest extends TestCase
         $fooItem = $this->injector->getInstance(FooItemInterface::class);
         $response = ($fooItem)('hello');
         $this->assertSame('https://httpbin.org/anything/hello', $response['url']);
+        $this->assertSame('query: https://httpbin.org/anything/hello({"id":"hello"})', (string) $this->logger);
     }
 }

--- a/tests/WebQueryTest.php
+++ b/tests/WebQueryTest.php
@@ -11,8 +11,8 @@ class WebQueryTest extends TestCase
 {
     public function testRequest(): void
     {
-        $webQuery = new WebApiQuery(new Client(), new MediaQueryLogger());
-        $response = $webQuery->request('GET', 'https://httpbin.org/anything/foo', ['id' => '1']);
+        $webQuery = new WebApiQuery(new Client(), new MediaQueryLogger(), ['domain1' => 'httpbin.org']);
+        $response = $webQuery->request('GET', 'https://{domain1}/anything/foo', ['id' => '1']);
         $this->assertSame('GET', $response['method']);
     }
 }

--- a/tests/WebQueryTest.php
+++ b/tests/WebQueryTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+
+use GuzzleHttp\Client;
+use PHPUnit\Framework\TestCase;
+
+class WebQueryTest extends TestCase
+{
+    public function testRequest(): void
+    {
+        $webQuery = new WebApiQuery(new Client(), new MediaQueryLogger());
+        $response = $webQuery->request('GET', 'https://httpbin.org/anything/foo', ['id' => '1']);
+        $this->assertSame('GET', $response['method']);
+    }
+}

--- a/tests/WebQueryTest.php
+++ b/tests/WebQueryTest.php
@@ -6,6 +6,7 @@ namespace Ray\MediaQuery;
 
 use GuzzleHttp\Client;
 use PHPUnit\Framework\TestCase;
+use Ray\MediaQuery\Exception\WebApiRequestException;
 
 class WebQueryTest extends TestCase
 {
@@ -14,5 +15,12 @@ class WebQueryTest extends TestCase
         $webQuery = new WebApiQuery(new Client(), new MediaQueryLogger(), ['domain1' => 'httpbin.org']);
         $response = $webQuery->request('GET', 'https://{domain1}/anything/foo', ['id' => '1']);
         $this->assertSame('GET', $response['method']);
+    }
+
+    public function testInvalidRequest(): void
+    {
+        $this->expectException(WebApiRequestException::class);
+        $webQuery = new WebApiQuery(new Client(), new MediaQueryLogger(), []);
+        $webQuery->request('GET', 'https://__invalid__/', []);
     }
 }


### PR DESCRIPTION
# Web API

インターフェイスをWebAPIリクエストにバインドするためには`WebQuery`の属性をつけ、`method`と`uri`を指定し`uri`はuri templateを指定します。メソッドの引数がuri templateにバインドされ、Web APIリクエストが行われるリクエストオブジェクトが生成されインジェクトされます。

```php
interface GetPostInterface
{
    #[WebQuery(method: 'GET', uri: 'https://{domain}/posts/{id}')]
    public function __invoke(string $id): array;
}
```

認証のためのヘッダーの指定などはGuzzleのClinetInterfaceをバインドして行います。

```php
$this->bind(ClientInterface::class)->toProvider(YourGuzzleClientProvicer::class);
```

WebQueryの時と同じようにVOを渡す事もできます。