### PR TITLE
Replace deprecated NamedArgumentConstructorAnnotation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "ext-json": "*",
         "ext-pdo": "*",
         "aura/sql": "^3.0",
-        "doctrine/annotations": "^1.11",
+        "doctrine/annotations": "^1.12",
         "guzzlehttp/guzzle": "^6.3 || ^7.2",
         "pagerfanta/pagerfanta": "^1.1",
         "ray/aop": "^2.10.4",

--- a/src/Annotation/DbQuery.php
+++ b/src/Annotation/DbQuery.php
@@ -5,14 +5,15 @@ declare(strict_types=1);
 namespace Ray\MediaQuery\Annotation;
 
 use Attribute;
-use Doctrine\Common\Annotations\NamedArgumentConstructorAnnotation;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * @Annotation
  * @Target("METHOD")
+ * @NamedArgumentConstructor
  */
 #[Attribute(Attribute::TARGET_METHOD)]
-final class DbQuery implements NamedArgumentConstructorAnnotation
+final class DbQuery
 {
     /** @var string */
     public $id;

--- a/src/Annotation/Pager.php
+++ b/src/Annotation/Pager.php
@@ -5,14 +5,15 @@ declare(strict_types=1);
 namespace Ray\MediaQuery\Annotation;
 
 use Attribute;
-use Doctrine\Common\Annotations\NamedArgumentConstructorAnnotation;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * @Annotation
  * @Target("METHOD")
+ * @NamedArgumentConstructor
  */
 #[Attribute(Attribute::TARGET_METHOD)]
-final class Pager implements NamedArgumentConstructorAnnotation
+final class Pager
 {
     /** @var int */
     public $perPage;

--- a/src/Annotation/WebQuery.php
+++ b/src/Annotation/WebQuery.php
@@ -5,14 +5,15 @@ declare(strict_types=1);
 namespace Ray\MediaQuery\Annotation;
 
 use Attribute;
-use Doctrine\Common\Annotations\NamedArgumentConstructorAnnotation;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * @Annotation
  * @Target("METHOD")
+ * @NamedArgumentConstructor
  */
 #[Attribute(Attribute::TARGET_METHOD)]
-final class WebQuery implements NamedArgumentConstructorAnnotation
+final class WebQuery
 {
     /** @var string */
     public $method;


### PR DESCRIPTION
`@NamedArgumentConstructor` is recommended way since doctrine/annotation 1.12.