### PR TITLE
[BC break] Add annotation type to specify return type

### DIFF
--- a/src/Annotation/DbQuery.php
+++ b/src/Annotation/DbQuery.php
@@ -21,9 +21,19 @@ final class DbQuery
     /** @var string */
     public $entity;
 
-    public function __construct(string $id, string $entity = '')
+    /**
+     * @Enum({"row", "row_list", "exec"})
+     * @var 'row'|'row_list'|'exec'
+     */
+    public $type = 'row_list';
+
+    /**
+     * @param 'row'|'row_list'|'exec' $type
+     */
+    public function __construct(string $id, string $entity = '', string $type = 'row_list')
     {
         $this->id = $id;
         $this->entity = $entity;
+        $this->type = $type;
     }
 }

--- a/src/DbQueryInterceptor.php
+++ b/src/DbQueryInterceptor.php
@@ -12,7 +12,6 @@ use Ray\MediaQuery\Annotation\Pager;
 
 use function class_exists;
 use function method_exists;
-use function substr;
 
 class DbQueryInterceptor implements MethodInterceptor
 {
@@ -48,7 +47,7 @@ class DbQueryInterceptor implements MethodInterceptor
 
         $fetchStyle = $this->getFetchMode($dbQury);
 
-        return $this->sqlQuery($dbQury->id, $values, $fetchStyle, $dbQury->entity);
+        return $this->sqlQuery($dbQury, $values, $fetchStyle, $dbQury->entity);
     }
 
     /**
@@ -74,18 +73,17 @@ class DbQueryInterceptor implements MethodInterceptor
      *
      * @return array<mixed>|object|null
      */
-    private function sqlQuery(string $queryId, array $values, int $fetchStyle, $fetchArg)
+    private function sqlQuery(DbQuery $dbQuery, array $values, int $fetchStyle, $fetchArg)
     {
-        $postFix = substr($queryId, -4);
-        if ($postFix === 'list') {
-            return $this->sqlQuery->getRowList($queryId, $values, $fetchStyle, $fetchArg);
+        if ($dbQuery->type === 'row_list') {
+            return $this->sqlQuery->getRowList($dbQuery->id, $values, $fetchStyle, $fetchArg);
         }
 
-        if ($postFix === 'item') {
-            return $this->sqlQuery->getRow($queryId, $values, $fetchStyle, $fetchArg);
+        if ($dbQuery->type === 'row') {
+            return $this->sqlQuery->getRow($dbQuery->id, $values, $fetchStyle, $fetchArg);
         }
 
-        $this->sqlQuery->exec($queryId, $values);
+        $this->sqlQuery->exec($dbQuery->id, $values);
 
         return [];
     }

--- a/tests/DbQueryModuleTest.php
+++ b/tests/DbQueryModuleTest.php
@@ -52,7 +52,7 @@ class DbQueryModuleTest extends TestCase
         ]);
         $sqlDir = dirname(__DIR__) . '/tests/sql';
         $dbQueryConfig = new DbQueryConfig($sqlDir);
-        $module = new MediaQueryModule($mediaQueries, [$dbQueryConfig], new AuraSqlModule('sqlite::memory:', '', '', '', [PDO::ATTR_STRINGIFY_FETCHES => true])); // @phpstan-ignore-line
+        $module = new MediaQueryModule($mediaQueries, [$dbQueryConfig], new AuraSqlModule('sqlite::memory:', '', '', '', [PDO::ATTR_STRINGIFY_FETCHES => true]));
         $this->injector = new Injector($module, __DIR__ . '/tmp');
         $pdo = $this->injector->getInstance(ExtendedPdoInterface::class);
         assert($pdo instanceof ExtendedPdoInterface);

--- a/tests/Fake/Queries/PromiseItemInterface.php
+++ b/tests/Fake/Queries/PromiseItemInterface.php
@@ -9,9 +9,9 @@ use Ray\MediaQuery\Annotation\DbQuery;
 interface PromiseItemInterface
 {
     /**
-     * @DbQuery("promise_item")
+     * @DbQuery("promise_item", type="row")
      * @return array{id: string, title: string, time: string}
      */
-    #[DbQuery('promise_item')]
+    #[DbQuery('promise_item', type:'row')]
     public function get(string $id): array;
 }

--- a/tests/Fake/Queries/PromiseListInterface.php
+++ b/tests/Fake/Queries/PromiseListInterface.php
@@ -9,7 +9,7 @@ use Ray\MediaQuery\Annotation\DbQuery;
 interface PromiseListInterface
 {
     /**
-     * @DbQuery("promise_list")
+     * @DbQuery("promise_list", type="row_list")
      * @return array{id: string, title: string, time: string}
      */
     #[DbQuery('promise_list')]

--- a/tests/Fake/Queries/TodoConstcuctEntityInterface.php
+++ b/tests/Fake/Queries/TodoConstcuctEntityInterface.php
@@ -11,7 +11,7 @@ use Ray\MediaQuery\Entity\TodoConstruct;
 interface TodoConstcuctEntityInterface
 {
     /**
-     * @DbQuery(id="todo_item", entity=TodoConstruct::class)
+     * @DbQuery(id="todo_item", entity=TodoConstruct::class, type="row")
      */
     #[DbQuery('todo_item', entity: TodoConstruct::class)]
     public function getItem(string $id): TodoConstruct;

--- a/tests/Fake/Queries/TodoEntityInterface.php
+++ b/tests/Fake/Queries/TodoEntityInterface.php
@@ -10,9 +10,9 @@ use Ray\MediaQuery\Entity\Todo;
 interface TodoEntityInterface
 {
     /**
-     * @DbQuery(id="todo_item", entity=Todo::class)
+     * @DbQuery(id="todo_item", entity=Todo::class, type="row")
      */
-    #[DbQuery('todo_item', entity: Todo::class)]
+    #[DbQuery('todo_item', entity: Todo::class, type:'row')]
     public function getItem(string $id): Todo;
 
     /**

--- a/tests/Fake/Queries/TodoItemInterface.php
+++ b/tests/Fake/Queries/TodoItemInterface.php
@@ -9,9 +9,9 @@ use Ray\MediaQuery\Annotation\DbQuery;
 interface TodoItemInterface
 {
     /**
-     * @DbQuery("todo_item")
+     * @DbQuery("todo_item", type="row")
      * @return array{id: string, title: string}
      */
-    #[DbQuery('todo_item')]
+    #[DbQuery('todo_item', type:'row')]
     public function __invoke(string $id): array;
 }

--- a/vendor-bin/tools/composer.lock
+++ b/vendor-bin/tools/composer.lock
@@ -1621,16 +1621,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.5.7",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "7fb7e2e1e9f3d59a26a413b2d3d5e47f0edb75ac"
+                "reference": "b480ba2ae0699a72d43a340c20b9c00ede91ee3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/7fb7e2e1e9f3d59a26a413b2d3d5e47f0edb75ac",
-                "reference": "7fb7e2e1e9f3d59a26a413b2d3d5e47f0edb75ac",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b480ba2ae0699a72d43a340c20b9c00ede91ee3e",
+                "reference": "b480ba2ae0699a72d43a340c20b9c00ede91ee3e",
                 "shasum": ""
             },
             "require": {
@@ -1656,7 +1656,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.5.7"
+                "source": "https://github.com/phpstan/phpstan/tree/1.6.0"
             },
             "funding": [
                 {
@@ -1676,7 +1676,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-20T12:20:27+00:00"
+            "time": "2022-04-26T05:43:03+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -4580,5 +4580,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
今までidのpostfixで指定していたDBフェッチの戻り値、`row`, `row_list`をアノテーションまたはアトリビュートの`type`で指定します。

アノテーションの場合：

```php
interface TodoItemInterface
{
    /**
     * @DbQuery("todo_item", type="row")
     * @return array{id: string, title: string}
     */
    public function __invoke(string $id): array;
}
```

アトリビュートの場合：

```php
interface TodoItemInterface
{
    #[DbQuery('todo_item', type： "row")]
    /**
     * @return array{id: string, title: string}
     */
    public function __invoke(string $id): array;
}
```

* デフォルトは`row_list`です。
* 値を返さない`exec`も利用可能です。

後方互換性を破壊するので`0.9`としてリリースします。