### PR TITLE
add support for enum value to ParamConverter

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,7 @@
   <testsuites>
     <testsuite name="Ray.MediaQuery test suite" >
       <directory>tests</directory>
+      <directory phpVersion="8.1.0" phpVersionOperator=">=">tests-php81</directory>
     </testsuite>
   </testsuites>
   <php>

--- a/src/ParamConverter.php
+++ b/src/ParamConverter.php
@@ -7,9 +7,14 @@ namespace Ray\MediaQuery;
 use DateTimeInterface;
 use Ray\MediaQuery\Exception\CouldNotBeConvertedException;
 
+use function assert;
+use function enum_exists;
+use function function_exists;
+use function get_class;
 use function is_object;
 use function method_exists;
 use function print_r;
+use function property_exists;
 
 class ParamConverter implements ParamConverterInterface
 {
@@ -38,6 +43,12 @@ class ParamConverter implements ParamConverterInterface
 
             if ($value instanceof ToScalarInterface) {
                 $value = $value->toScalar();
+                continue;
+            }
+
+            if (function_exists('enum_exists') && enum_exists(get_class($value))) {
+                assert(property_exists($value, 'name'));
+                $value = $value->name;
                 continue;
             }
 

--- a/tests-php81/EnumParamConverterTest.php
+++ b/tests-php81/EnumParamConverterTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+
+use PHPUnit\Framework\TestCase;
+
+class EnumParamConverterTest extends TestCase
+{
+    public function testInvoke(): void
+    {
+        $values = ['status' => FakeEnum::public];
+        (new ParamConverter())($values);
+        $this->assertSame(['status' => 'public'], $values);
+    }
+}

--- a/tests/DbQueryModuleTest.php
+++ b/tests/DbQueryModuleTest.php
@@ -63,6 +63,7 @@ class DbQueryModuleTest extends TestCase
         ]);
         $sqlDir = dirname(__DIR__) . '/tests/sql';
         $dbQueryConfig = new DbQueryConfig($sqlDir);
+        /** @phpstan-ignore-next-line  */
         $module = new MediaQueryModule($mediaQueries, [$dbQueryConfig], new AuraSqlModule('sqlite::memory:', '', '', '', [PDO::ATTR_STRINGIFY_FETCHES => true]));
         $this->injector = new Injector($module, __DIR__ . '/tmp');
         $pdo = $this->injector->getInstance(ExtendedPdoInterface::class);

--- a/tests/Fake/FakeEnum.php
+++ b/tests/Fake/FakeEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Ray\MediaQuery;
+
+enum FakeEnum
+{
+    case draft;
+    case public;
+}

--- a/tests/ParamConverterTest.php
+++ b/tests/ParamConverterTest.php
@@ -17,7 +17,7 @@ class ParamConverterTest extends TestCase
         $this->assertSame(['date_val' => UnixEpocTime::TEXT, 'bool_val' => true, 'string_val' => 'a'], $values);
     }
 
-    public function testInvaliParam(): void
+    public function testInvalidParam(): void
     {
         $this->expectException(CouldNotBeConvertedException::class);
         $values = ['invalid' => new stdClass()];


### PR DESCRIPTION
ParamConverterがEnumを扱えるように変更しました。

例）

enum
```php
<?php
enum Status: string
{
    case DRAFT = 'draft';
    case VALID = 'valid';
}
```

Resource
```php
<?php
class Article extends ResourceObject
{
    public function __construct(private readonly ArticleInterface $article)
    {
    }

    public function onPost(string $title, string $body, string $status): static
    {
        $this->article->create($title, $body, Status::tryFrom($status) ?? Status::DRAFT);

        return $this;
    }
}
```

Query
```php
<?php
interface Article
{
    #[DbQuery(id:'create_article')]
    public function create(
        string $title,
        string $body,
        Status $status,
    ): void;
}
```

create_article.sql
```sql
INSERT INTO articles (`title`, `body`, `status`) VALUES (:title, :body, :status);
```
