### PR TITLE
Respect the return type of the entity

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -36,7 +36,7 @@ interface TodoAddInterface
 interface PostItemInterface
 {
     #[WebQuery('user_item')]
-    public function get(string $id): array;
+    public function item(string $id): Post;
 }
 ```
 
@@ -75,11 +75,11 @@ protected function configure(): void
 }
 ```
 
-MediaQueryModuleはAuraSqlModuleのインストールが必要です。
+注) MediaQueryModuleはAuraSqlModuleのインストールが必要です。
 
 ### 注入
 
-インtーフェイスからオブジェクトが直接生成され、インジェクトされます。実装クラスのコーディングが不要です。
+実装クラスをコーディングすることなく、インターフェイスからクエリー実行オブジェクトが生成されインジェクトされます。
 
 ```php
 class Todo
@@ -97,29 +97,44 @@ class Todo
 
 ### DbQuery
 
-SQL実行がメソッドにマップされ、IDで指定されたSQLをメソッドの引数でバインドして実行します。
-例えばIDが`todo_item`の指定では`todo_item.sql`SQL文に`['id => $id]`をバインドして実行します。
-
-* `$sqlDir`ディレクトリにSQLファイルを用意します。
-* SQL実行の戻り値が単一行なら`item`、複数行なら`list`のpostfixを付けます。
-* SQLファイルには複数のSQL文が記述できます。最後の行のSELECTが返り値になります。
-
-#### Entity
-
-* SQL実行結果を用意したエンティティクラスを`entity`で指定して変換 (hydrate)することができます。
+メソッドをコールするとIDで指定されたSQLをメソッドの引数でバインドして実行します。
+例えばIDが`todo_item`の指定では`todo_item.sql`SQL文を`['id => $id]`でバインドして実行します。
 
 ```php
 interface TodoItemInterface
 {
-    #[DbQuery('todo_item', entity: Todo::class)]
-    public function getItem(string $id): Todo;
+    #[DbQuery('todo_item', type: 'row')]
+    public function item(string $id): array;
+
+    #[DbQuery('todo_list')]
+    /** @return array<Todo> */
+    public function list(string $id): array;
+}
+```
+
+* 結果がrow`(`array<string, scalar>>`)の場合は`type:'row'`を指定します。`row_list`(`array<int, array<string, scalar>>>`)にはtype指定は不要です。
+* SQLファイルには複数のSQL文が記述できます。その場合には最後の行のSELECTが戻り値になります。
+
+#### Entity
+
+メソッドの戻り値をエンティティクラスにするとSQL実行結果がハイドレートされます。
+
+```php
+interface TodoItemInterface
+{
+    #[DbQuery('todo_item')]
+    public function item(string $id): Todo;
+
+    #[DbQuery('todo_list')]
+    /** @return array<Todo> */
+    public function list(string $id): array;
 }
 ```
 ```php
 final class Todo
 {
-    public string $id;
-    public string $title;
+    public readonly string $id;
+    public readonly string $title;
 }
 ```
 
@@ -136,14 +151,14 @@ class Invoice
 }
 ```
 
-コンストラクタがあると、フェッチしたデータでコールされます。
+エンティティにコンストラクタがあると、フェッチしたデータでコールされます。
 
 ```php
 final class Todo
 {
     public function __construct(
-        public string $id,
-        public string $title
+        public readonly string $id,
+        public readonly string $title
     ) {}
 }
 ```
@@ -235,14 +250,14 @@ use Ray\MediaQuery\PagesInterface;
 interface TodoList
 {
     #[DbQuery, Pager(perPage: 10, template: '/{?page}')]
-    public function __invoke(): PagesInterface;
+    public function __invoke(): Pages;
 }
 ```
 
 ページ毎のアイテム数をperPageで指定しますが、動的な値の場合は以下のようにページ数を表す引数の名前を文字列を指定します。
 ```php
     #[DbQuery, Pager(perPage: 'pageNum', template: '/{?page}')]
-    public function __invoke($pageNum): PagesInterface;
+    public function __invoke($pageNum): Pages;
 ```
 
 `count()`で件数が取得でき、ページ番号で配列アクセスをするとページオブジェクトが取得できます。
@@ -262,6 +277,13 @@ $page = $pages[2]; // 配列アクセスをした時にそのページのDBク�
 // (string) $page // pager html
 ```
 
+エンティティクラスにハイドレーションを行うときは`@return`で指定します。
+
+```php
+    #[DbQuery, Pager(perPage: 'pageNum', template: '/{?page}')]
+    /** @return array<Todo> */
+    public function __invoke($pageNum): Pages;
+```
 ## SqlQuery
 
 `SqlQuery`はSQLファイルのIDを指定してSQLを実行します。

--- a/UPGRADE.ja.md
+++ b/UPGRADE.ja.md
@@ -1,0 +1,57 @@
+# Upgrade Guide
+
+破壊的変更が行われたv0.xからv1.0への移行について説明します。
+なお、セマンティックバージョンに従いv1.0からは破壊的変更は行われません。
+
+## from v0.7
+
+### エンティティ
+
+`entity`アトリビュートが無効になりました。使用するとエラーになります。
+
+ハイドレート（戻り値にエンティティを使用）する場合は`entity`と`type`のアトリビュートを取り除きます。
+
+```diff
+interface TodoInterface
+{
+-   #[DbQuery('todo_item', entity: Todo::class, type:'row')]
++   #[DbQuery('todo_item')]
+    public function item(string $id): Todo;
+
+-   #[DbQuery('todo_list', entity: Todo::class)]
++   #[DbQuery('todo_list')]
++   /** @return array<Todo>> */ 
+    public function list(): array;
+
+```
+
+ページングの時はジェネリクスで指定します。戻り値をハイドレートするときは廃止された`entity`に変わってこの指定が必須になりました。
+
+```diff
+interface TodoPagerInterface
+{
+-   #[DbQuery('todo_list'), Pager(perPage: 10, template: '/{?page}'), entity: Todo:class]
++   #[DbQuery('todo_list'), Pager(perPage: 10, template: '/{?page}')]
++   /**　@return Pages<Todo>　*/
+    public function __invoke(): Pages;
+}
+```
+
+### array
+
+戻り値がarrayで`row`の形式で値が戻る時のみ`type: 'row'`の指定が必要です。これはarrayだけではrow (array<string>)なのかrow_list (array<array<string>>)なのか判別がつかないからです。エンティティにハイドレートしない場合は従来と変更がありません。
+
+```php
+interface TodoInterface
+{
+    #[DbQuery('todo_item', type:'row')]
+    public function item(string $id): array;
+  
+    #[DbQuery('todo_list')]
+    public function list(): array;
+}
+```
+
+## from v0.6
+
+`item`や`list`などの接尾語の指定は無効になります。その他はv0.7からの移行と同じです。

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,57 @@
+## UPGRADE GUIDE
+
+This section describes the transition from v0.x to v1.0, which has undergone a destructive change.
+Note that no destructive changes will be made from v1.0 according to the semantic version.
+
+## from v0.7
+
+### エンティティ
+
+The `entity` attribute is no longer valid. Use of it will result in an error.
+
+Remove the `entity` and `type` attributes if you want to hydrate (use entities in the return value).
+
+```diff
+interface TodoInterface
+{
+-   #[DbQuery('todo_item', entity: Todo::class, type:'row')]
++   #[DbQuery('todo_item')]
+    public function item(string $id): Todo;
+
+-   #[DbQuery('todo_list', entity: Todo::class)]
++   #[DbQuery('todo_list')]
++   /** @return array<Todo>> */ 
+    public function list(): array;
+
+```
+
+ページングの時はジェネリクスで指定します。戻り値をハイドレートするときは廃止された`entity`に変わってこの指定が必須になりました。
+
+```diff
+interface TodoPagerInterface
+{
+-   #[DbQuery('todo_list'), Pager(perPage: 10, template: '/{?page}'), entity: Todo:class]
++   #[DbQuery('todo_list'), Pager(perPage: 10, template: '/{?page}')]
++   /**　@return Pages<Todo>　*/
+    public function __invoke(): Pages;
+}
+```
+
+### array
+
+The `type: 'row'` is required only when the return value is an array and the value is returned in the form `row`. This is because it is not possible to determine whether the return value is a row (array<string>) or row_list (array<array<string>>) from an array alone. If the entity is not hydrated, there is no change from the previous case.
+
+```php
+interface TodoInterface
+{
+    #[DbQuery('todo_item', type:'row')]
+    public function item(string $id): array;
+  
+    #[DbQuery('todo_list')]
+    public function list(): array;
+}
+```
+
+## from v0.6
+
+The specification of suffixes such as `item` and `list` will be disabled. Otherwise, the transition is the same as from v0.7.

--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,14 @@
         "doctrine/annotations": "^1.12",
         "guzzlehttp/guzzle": "^6.3 || ^7.2",
         "koriym/null-object": "^1.0.1",
+        "nikic/php-parser": "^4.15",
         "pagerfanta/pagerfanta": "^3.5",
+        "phpdocumentor/reflection-docblock": "^5.3",
         "ray/aop": "^2.10.4",
         "ray/aura-sql-module": "^1.12.0",
         "ray/di": "^2.12",
         "roave/better-reflection": "^4.12 || ^5.6",
-        "symfony/polyfill-php81": "^1.24",
-        "nikic/php-parser": "^4.15"
+        "symfony/polyfill-php81": "^1.24"
     },
     "require-dev": {
         "doctrine/coding-standard": "^10.0",

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "nikic/php-parser": "^4.15",
         "pagerfanta/pagerfanta": "^3.5",
         "phpdocumentor/reflection-docblock": "^5.3",
+        "phpdocumentor/type-resolver": "^1.6.1",
         "ray/aop": "^2.10.4",
         "ray/aura-sql-module": "^1.12.0",
         "ray/di": "^2.12",

--- a/src/Annotation/DbQuery.php
+++ b/src/Annotation/DbQuery.php
@@ -20,7 +20,6 @@ final class DbQuery
         public string $id,
         public string $type = 'row_list',
         /** @var ?class-string */
-        public string|null $entity = null,
     ) {
     }
 }

--- a/src/Annotation/DbQuery.php
+++ b/src/Annotation/DbQuery.php
@@ -18,8 +18,7 @@ final class DbQuery
     /** @param 'row'|'row_list' $type */
     public function __construct(
         public string $id,
-        public string $type = 'row_list',
-        /** @var ?class-string */
+        public string $ty2pe = 'row_list',
     ) {
     }
 }

--- a/src/Annotation/DbQuery.php
+++ b/src/Annotation/DbQuery.php
@@ -18,7 +18,7 @@ final class DbQuery
     /** @param 'row'|'row_list' $type */
     public function __construct(
         public string $id,
-        public string $ty2pe = 'row_list',
+        public string $type = 'row_list',
     ) {
     }
 }

--- a/src/CamelCaseTrait.php
+++ b/src/CamelCaseTrait.php
@@ -12,7 +12,7 @@ trait CamelCaseTrait
 {
     public function __set(string $name, mixed $value): void
     {
-        $propName =  lcfirst(str_replace('_', '', ucwords($name, '_')));
+        $propName = lcfirst(str_replace('_', '', ucwords($name, '_')));
         $this->{$propName} = $value;
     }
 }

--- a/src/DbQueryInterceptor.php
+++ b/src/DbQueryInterceptor.php
@@ -25,6 +25,7 @@ class DbQueryInterceptor implements MethodInterceptor
         private SqlQueryInterface $sqlQuery,
         private MediaQueryLoggerInterface $logger,
         private ParamInjectorInterface $paramInjector,
+        private ReturnEntityInterface $returnEntity,
     ) {
     }
 
@@ -36,7 +37,7 @@ class DbQueryInterceptor implements MethodInterceptor
         $dbQuery = $method->getAnnotation(DbQuery::class);
         $pager = $method->getAnnotation(Pager::class);
         $values = $this->paramInjector->getArgumentes($invocation);
-        $entity = (new ReturnEntity($method))->type;
+        $entity = ($this->returnEntity)($method);
         if ($pager instanceof Pager) {
             return $this->getPager($dbQuery->id, $values, $pager, $entity);
         }

--- a/src/DbQueryInterceptor.php
+++ b/src/DbQueryInterceptor.php
@@ -41,7 +41,7 @@ class DbQueryInterceptor implements MethodInterceptor
             return $this->getPager($dbQuery->id, $values, $pager, $entity);
         }
 
-        $fetchStyle = $this->getFetchMode((string) $entity);
+        $fetchStyle = $this->getFetchMode($entity);
 
         /** @var ReflectionNamedType|null $returnType */
         $returnType = $invocation->getMethod()->getReturnType();
@@ -52,11 +52,11 @@ class DbQueryInterceptor implements MethodInterceptor
     /**
      * @param ?class-string $entity
      *
-     * @return  PDO::FETCH_ASSOC|PDO::FETCH_CLASS|PDO::FETCH_FUNC $fetchStyle
+     * @return PDO::FETCH_ASSOC|PDO::FETCH_CLASS|PDO::FETCH_FUNC $fetchStyle
      */
-    private function getFetchMode(string $entity): int
+    private function getFetchMode(string|null $entity): int
     {
-        if (! class_exists($entity)) {
+        if ($entity === null) {
             return PDO::FETCH_ASSOC;
         }
 

--- a/src/DbQueryInterceptor.php
+++ b/src/DbQueryInterceptor.php
@@ -38,15 +38,15 @@ class DbQueryInterceptor implements MethodInterceptor
         $values = $this->paramInjector->getArgumentes($invocation);
         $entity = (new ReturnEntity($method))->type;
         if ($pager instanceof Pager) {
-            return $this->getPager($dbQuery->id, $values, $pager, $dbQuery->entity);
+            return $this->getPager($dbQuery->id, $values, $pager, $entity);
         }
 
-        $fetchStyle = $this->getFetchMode($entity);
+        $fetchStyle = $this->getFetchMode((string) $entity);
 
         /** @var ReflectionNamedType|null $returnType */
         $returnType = $invocation->getMethod()->getReturnType();
 
-        return $this->sqlQuery($returnType, $dbQuery, $values, $fetchStyle, (string) $dbQuery->entity);
+        return $this->sqlQuery($returnType, $dbQuery, $values, $fetchStyle, (string) $entity);
     }
 
     /**
@@ -71,7 +71,7 @@ class DbQueryInterceptor implements MethodInterceptor
      */
     private function sqlQuery(ReflectionNamedType|null $returnType, DbQuery $dbQuery, array $values, int $fetchStyle, int|string|callable $fetchArg): array|object|null
     {
-        if ($dbQuery->type === 'row' || $returnType && class_exists($returnType->getName())) {
+        if ($dbQuery->type === 'row' || ($returnType && class_exists($returnType->getName()))) {
             return $this->sqlQuery->getRow($dbQuery->id, $values, $fetchStyle, $fetchArg);
         }
 

--- a/src/MediaQueryDbModule.php
+++ b/src/MediaQueryDbModule.php
@@ -26,5 +26,6 @@ class MediaQueryDbModule extends AbstractModule
             [DbQueryInterceptor::class],
         );
         $this->bind()->annotatedWith(SqlDir::class)->toInstance($this->configs->sqlDir);
+        $this->bind(ReturnEntityInterface::class)->to(ReturnEntity::class);
     }
 }

--- a/src/Pages.php
+++ b/src/Pages.php
@@ -10,7 +10,7 @@ use Ray\AuraSqlModule\Pagerfanta\ExtendedPdoAdapter;
 use Ray\AuraSqlModule\Pagerfanta\Page;
 use Ray\MediaQuery\Exception\LogicException;
 
-/** @template T of ?class-string */
+/** @template T of class-string|mixed */
 class Pages implements PagesInterface
 {
     /** @param array<string, mixed> $params */

--- a/src/Pages.php
+++ b/src/Pages.php
@@ -10,6 +10,7 @@ use Ray\AuraSqlModule\Pagerfanta\ExtendedPdoAdapter;
 use Ray\AuraSqlModule\Pagerfanta\Page;
 use Ray\MediaQuery\Exception\LogicException;
 
+/** @template T of ?class-string */
 class Pages implements PagesInterface
 {
     /** @param array<string, mixed> $params */

--- a/src/ReturnEntity.php
+++ b/src/ReturnEntity.php
@@ -7,6 +7,7 @@ namespace Ray\MediaQuery;
 use phpDocumentor\Reflection\DocBlock\Tags\Return_;
 use phpDocumentor\Reflection\DocBlockFactory;
 use phpDocumentor\Reflection\Types\Array_;
+use phpDocumentor\Reflection\Types\Collection;
 use phpDocumentor\Reflection\Types\ContextFactory;
 use phpDocumentor\Reflection\Types\Object_;
 use ReflectionMethod;
@@ -17,8 +18,8 @@ use function substr;
 
 final class ReturnEntity
 {
-    /** @var class-string  */
-    public string|null $type = '';
+    /** @var ?class-string  */
+    public string|null $type = null;
 
     public function __construct(ReflectionMethod $method)
     {
@@ -28,7 +29,7 @@ final class ReturnEntity
         }
 
         $returnTypeClass = $returnType->getName();
-        if (class_exists($returnTypeClass)) {
+        if (class_exists($returnTypeClass) && $returnTypeClass !== Pages::class) {
             $this->type = $returnTypeClass;
 
             return;
@@ -50,7 +51,7 @@ final class ReturnEntity
         $return = $returns[0];
         assert($return instanceof Return_);
         $type = $return->getType();
-        if (! $type instanceof Array_) {
+        if (! $type instanceof Array_ && ! $type instanceof Collection) {
             return;
         }
 

--- a/src/ReturnEntity.php
+++ b/src/ReturnEntity.php
@@ -28,7 +28,7 @@ final class ReturnEntity
             return;
         }
 
-        $returnTypeClass = $returnType->getName();
+        $returnTypeClass = (string) $returnType;
         if (class_exists($returnTypeClass) && $returnTypeClass !== Pages::class) {
             $this->type = $returnTypeClass;
 
@@ -66,6 +66,9 @@ final class ReturnEntity
             return;
         }
 
-        $this->type = substr($fqsen, 1);
+        $classString = substr($fqsen, 1);
+        assert(class_exists($classString));
+
+        $this->type = $classString;
     }
 }

--- a/src/ReturnEntity.php
+++ b/src/ReturnEntity.php
@@ -35,6 +35,11 @@ final class ReturnEntity
             return;
         }
 
+        $this->docblock($method);
+    }
+
+    private function docblock(ReflectionMethod $method): void
+    {
         $factory = DocBlockFactory::createInstance();
         $context = (new ContextFactory())->createFromReflector($method);
         $docComment = $method->getDocComment();

--- a/src/ReturnEntity.php
+++ b/src/ReturnEntity.php
@@ -67,10 +67,6 @@ final class ReturnEntity
 
         $fqsen = (string) $valueType->getFqsen();
 
-        if (! class_exists($fqsen)) {
-            return;
-        }
-
         $classString = substr($fqsen, 1);
         assert(class_exists($classString));
 

--- a/src/ReturnEntity.php
+++ b/src/ReturnEntity.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+
+use phpDocumentor\Reflection\DocBlock\Tags\Return_;
+use phpDocumentor\Reflection\DocBlockFactory;
+use phpDocumentor\Reflection\Types\Array_;
+use phpDocumentor\Reflection\Types\ContextFactory;
+use phpDocumentor\Reflection\Types\Object_;
+use ReflectionMethod;
+
+use function assert;
+use function class_exists;
+use function substr;
+
+final class ReturnEntity
+{
+    /** @var class-string  */
+    public string|null $type = '';
+
+    public function __construct(ReflectionMethod $method)
+    {
+        $returnType = $method->getReturnType();
+        if ($returnType === null) {
+            return;
+        }
+
+        $returnTypeClass = $returnType->getName();
+        if (class_exists($returnTypeClass)) {
+            $this->type = $returnTypeClass;
+
+            return;
+        }
+
+        $factory = DocBlockFactory::createInstance();
+        $context = (new ContextFactory())->createFromReflector($method);
+        $docComment = $method->getDocComment();
+        if ($docComment === false) {
+            return;
+        }
+
+        $docblock = $factory->create($docComment, $context);
+        $returns = $docblock->getTagsByName('return');
+        if (! isset($returns[0])) {
+            return;
+        }
+
+        $return = $returns[0];
+        assert($return instanceof Return_);
+        $type = $return->getType();
+        if (! $type instanceof Array_) {
+            return;
+        }
+
+        $valueType = $type->getValueType();
+        if (! $valueType instanceof Object_) {
+            return;
+        }
+
+        $fqsen = (string) $valueType->getFqsen();
+
+        if (! class_exists($fqsen)) {
+            return;
+        }
+
+        $this->type = substr($fqsen, 1);
+    }
+}

--- a/src/ReturnEntityInterface.php
+++ b/src/ReturnEntityInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+
+use ReflectionMethod;
+
+interface ReturnEntityInterface
+{
+    /** @return ?class-string  */
+    public function __invoke(ReflectionMethod $method): string|null;
+}

--- a/src/WebApiQuery.php
+++ b/src/WebApiQuery.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Ray\MediaQuery;
 
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\TransferException;
 use Ray\MediaQuery\Annotation\Qualifier\UriTemplateBindings;
 use Ray\MediaQuery\Exception\WebApiRequestException;
 
@@ -39,7 +39,7 @@ final class WebApiQuery implements WebApiQueryInterface
             $this->logger->log($boundUri, $query);
 
             return $body;
-        } catch (GuzzleException $e) {
+        } catch (TransferException $e) {
             throw new WebApiRequestException($e->getMessage(), (int) $e->getCode(), $e);
         }
     }

--- a/src/WebQueryInterceptor.php
+++ b/src/WebQueryInterceptor.php
@@ -19,7 +19,7 @@ final class WebQueryInterceptor implements MethodInterceptor
     ) {
     }
 
-    /** @return Pages|array<mixed> */
+    /** @return Pages<array<mixed>>|array<mixed> */
     public function invoke(MethodInvocation $invocation): Pages|array
     {
         $method = $invocation->getMethod();

--- a/tests/DbQueryModuleTest.php
+++ b/tests/DbQueryModuleTest.php
@@ -59,7 +59,7 @@ class DbQueryModuleTest extends TestCase
         ]);
         $sqlDir = dirname(__DIR__) . '/tests/sql';
         $dbQueryConfig = new DbQueryConfig($sqlDir);
-        $module = new MediaQueryModule($mediaQueries, [$dbQueryConfig], new AuraSqlModule('sqlite::memory:', '', '', '', [PDO::ATTR_STRINGIFY_FETCHES => true]));
+        $module = new MediaQueryModule($mediaQueries, [$dbQueryConfig], new AuraSqlModule('sqlite::memory:', '', '', '', [PDO::ATTR_STRINGIFY_FETCHES => true])); /* @phpstan-ignore-line */
         $this->injector = new Injector($module, __DIR__ . '/tmp');
         $pdo = $this->injector->getInstance(ExtendedPdoInterface::class);
         assert($pdo instanceof ExtendedPdoInterface);

--- a/tests/DbQueryModuleTest.php
+++ b/tests/DbQueryModuleTest.php
@@ -33,6 +33,7 @@ use function assert;
 use function dirname;
 use function file_get_contents;
 use function is_array;
+use function is_callable;
 
 class DbQueryModuleTest extends TestCase
 {
@@ -58,7 +59,6 @@ class DbQueryModuleTest extends TestCase
         ]);
         $sqlDir = dirname(__DIR__) . '/tests/sql';
         $dbQueryConfig = new DbQueryConfig($sqlDir);
-        /** @phpstan-ignore-next-line  */
         $module = new MediaQueryModule($mediaQueries, [$dbQueryConfig], new AuraSqlModule('sqlite::memory:', '', '', '', [PDO::ATTR_STRINGIFY_FETCHES => true]));
         $this->injector = new Injector($module, __DIR__ . '/tmp');
         $pdo = $this->injector->getInstance(ExtendedPdoInterface::class);
@@ -203,6 +203,7 @@ class DbQueryModuleTest extends TestCase
     {
         $this->expectException(PerPageNotIntTypeException::class);
         $todoList = $this->injector->getInstance(DynamicPerPageInvalidType::class);
+        assert(is_callable($todoList));
         $todoList('1');
     }
 

--- a/tests/Fake/Entity/FakeEntity.php
+++ b/tests/Fake/Entity/FakeEntity.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery\Entity;
+
+
+final class FakeEntity
+{
+    public function __construct(
+        public string $id
+    ){
+    }
+}

--- a/tests/Fake/FakeReturn.php
+++ b/tests/Fake/FakeReturn.php
@@ -26,4 +26,40 @@ final class FakeReturn
     {
         return [];
     }
+
+    public function noReturn()
+    {
+    }
+
+    public function noPhpDoc(): Pages
+    {
+    }
+
+    /**
+     * @todo Add return type!
+     */
+    public function noReturnDoc(): Pages
+    {
+    }
+
+    /**
+     * @return array<int>
+     */
+    public function nonEntityGeneric(): array
+    {
+    }
+
+    /**
+     * @return int
+     */
+    public function invalidReturnType(): array
+    {
+    }
+
+    /**
+     * @return array<array<string, string>>
+     */
+    public function returnArray(): array
+    {
+    }
 }

--- a/tests/Fake/FakeReturn.php
+++ b/tests/Fake/FakeReturn.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+use Ray\MediaQuery\Entity\FakeEntity;
+
+final class FakeReturn
+{
+    public function item(): FakeEntity
+    {
+        return new FakeEntity('1');
+    }
+
+    /**
+     * @return array<FakeEntity>
+     */
+    public function list(): array
+    {
+        return [
+            new FakeEntity('1')
+        ];
+    }
+
+    public function arrayList(): array
+    {
+        return [];
+    }
+}

--- a/tests/Fake/Queries/PagerEntityInterface.php
+++ b/tests/Fake/Queries/PagerEntityInterface.php
@@ -11,6 +11,9 @@ use Ray\MediaQuery\Pages;
 
 interface PagerEntityInterface
 {
-    #[DbQuery('todo_list', entity: TodoConstruct::class), Pager(perPage: 10, template: '/{?page}')]
+    #[DbQuery('todo_list'), Pager(perPage: 10, template: '/{?page}')]
+    /**
+     * @return Pages<TodoConstruct>
+     */
     public function __invoke(): Pages;
 }

--- a/tests/Fake/Queries/TodoConstcuctEntityInterface.php
+++ b/tests/Fake/Queries/TodoConstcuctEntityInterface.php
@@ -9,10 +9,10 @@ use Ray\MediaQuery\Entity\TodoConstruct;
 
 interface TodoConstcuctEntityInterface
 {
-    #[DbQuery('todo_item', entity: TodoConstruct::class, type: "row")]
+    #[DbQuery('todo_item')]
     public function getItem(string $id): TodoConstruct;
 
-    #[DbQuery('todo_list', entity: TodoConstruct::class)]
+    #[DbQuery('todo_list')]
     /**
      * @return array<TodoConstruct>
      */

--- a/tests/Fake/Queries/TodoConstcuctEntityInterface.php
+++ b/tests/Fake/Queries/TodoConstcuctEntityInterface.php
@@ -13,5 +13,8 @@ interface TodoConstcuctEntityInterface
     public function getItem(string $id): TodoConstruct;
 
     #[DbQuery('todo_list', entity: TodoConstruct::class)]
+    /**
+     * @return array<TodoConstruct>
+     */
     public function getList(): array;
 }

--- a/tests/Fake/Queries/TodoEntityInterface.php
+++ b/tests/Fake/Queries/TodoEntityInterface.php
@@ -13,5 +13,8 @@ interface TodoEntityInterface
     public function getItem(string $id): Todo;
 
     #[DbQuery('todo_list', entity: Todo::class)]
+    /**
+     * @return array<Todo>
+     */
     public function getList(): array;
 }

--- a/tests/Fake/Queries/TodoEntityInterface.php
+++ b/tests/Fake/Queries/TodoEntityInterface.php
@@ -9,10 +9,10 @@ use Ray\MediaQuery\Entity\Todo;
 
 interface TodoEntityInterface
 {
-    #[DbQuery('todo_item', entity: Todo::class)]
+    #[DbQuery('todo_item')]
     public function getItem(string $id): Todo;
 
-    #[DbQuery('todo_list', entity: Todo::class)]
+    #[DbQuery('todo_list')]
     /**
      * @return array<Todo>
      */

--- a/tests/Fake/Queries/TodoEntityInterface.php
+++ b/tests/Fake/Queries/TodoEntityInterface.php
@@ -9,7 +9,7 @@ use Ray\MediaQuery\Entity\Todo;
 
 interface TodoEntityInterface
 {
-    #[DbQuery('todo_item', entity: Todo::class, type:'row')]
+    #[DbQuery('todo_item', entity: Todo::class)]
     public function getItem(string $id): Todo;
 
     #[DbQuery('todo_list', entity: Todo::class)]

--- a/tests/ReturnTypeTest.php
+++ b/tests/ReturnTypeTest.php
@@ -25,4 +25,52 @@ class ReturnTypeTest extends TestCase
 
         $this->assertSame(FakeEntity::class, $entity->type);
     }
+
+    public function testNoReturnType(): void
+    {
+        $method = new ReflectionMethod(new FakeReturn(), 'noReturn');
+        $entity = new ReturnEntity($method);
+
+        $this->assertSame(null, $entity->type);
+    }
+
+    public function testnoPhpDoc(): void
+    {
+        $method = new ReflectionMethod(new FakeReturn(), 'noPhpDoc');
+        $entity = new ReturnEntity($method);
+
+        $this->assertSame(null, $entity->type);
+    }
+
+    public function testNoReturnDoc(): void
+    {
+        $method = new ReflectionMethod(new FakeReturn(), 'noReturnDoc');
+        $entity = new ReturnEntity($method);
+
+        $this->assertSame(null, $entity->type);
+    }
+
+    public function testNonEntityGeneric(): void
+    {
+        $method = new ReflectionMethod(new FakeReturn(), 'nonEntityGeneric');
+        $entity = new ReturnEntity($method);
+
+        $this->assertSame(null, $entity->type);
+    }
+
+    public function testInvalidReturnType(): void
+    {
+        $method = new ReflectionMethod(new FakeReturn(), 'invalidReturnType');
+        $entity = new ReturnEntity($method);
+
+        $this->assertSame(null, $entity->type);
+    }
+
+    public function testReturnArray(): void
+    {
+        $method = new ReflectionMethod(new FakeReturn(), 'returnArray');
+        $entity = new ReturnEntity($method);
+
+        $this->assertSame(null, $entity->type);
+    }
 }

--- a/tests/ReturnTypeTest.php
+++ b/tests/ReturnTypeTest.php
@@ -8,9 +8,6 @@ use PHPUnit\Framework\TestCase;
 use Ray\MediaQuery\Entity\FakeEntity;
 use ReflectionMethod;
 
-class Foo
-{
-}
 class ReturnTypeTest extends TestCase
 {
     public function testReturnItem(): void

--- a/tests/ReturnTypeTest.php
+++ b/tests/ReturnTypeTest.php
@@ -13,64 +13,64 @@ class ReturnTypeTest extends TestCase
     public function testReturnItem(): void
     {
         $method = new ReflectionMethod(new FakeReturn(), 'item');
-        $entity = new ReturnEntity($method);
+        $entity = (new ReturnEntity())($method);
 
-        $this->assertSame(FakeEntity::class, $entity->type);
+        $this->assertSame(FakeEntity::class, $entity);
     }
 
     public function testReturnList(): void
     {
         $method = new ReflectionMethod(new FakeReturn(), 'list');
-        $entity = new ReturnEntity($method);
+        $entity = (new ReturnEntity())($method);
 
-        $this->assertSame(FakeEntity::class, $entity->type);
+        $this->assertSame(FakeEntity::class, $entity);
     }
 
     public function testNoReturnType(): void
     {
         $method = new ReflectionMethod(new FakeReturn(), 'noReturn');
-        $entity = new ReturnEntity($method);
+        $entity = (new ReturnEntity())($method);
 
-        $this->assertSame(null, $entity->type);
+        $this->assertSame(null, $entity);
     }
 
     public function testnoPhpDoc(): void
     {
         $method = new ReflectionMethod(new FakeReturn(), 'noPhpDoc');
-        $entity = new ReturnEntity($method);
+        $entity = (new ReturnEntity())($method);
 
-        $this->assertSame(null, $entity->type);
+        $this->assertSame(null, $entity);
     }
 
     public function testNoReturnDoc(): void
     {
         $method = new ReflectionMethod(new FakeReturn(), 'noReturnDoc');
-        $entity = new ReturnEntity($method);
+        $entity = (new ReturnEntity())($method);
 
-        $this->assertSame(null, $entity->type);
+        $this->assertSame(null, $entity);
     }
 
     public function testNonEntityGeneric(): void
     {
         $method = new ReflectionMethod(new FakeReturn(), 'nonEntityGeneric');
-        $entity = new ReturnEntity($method);
+        $entity = (new ReturnEntity())($method);
 
-        $this->assertSame(null, $entity->type);
+        $this->assertSame(null, $entity);
     }
 
     public function testInvalidReturnType(): void
     {
         $method = new ReflectionMethod(new FakeReturn(), 'invalidReturnType');
-        $entity = new ReturnEntity($method);
+        $entity = (new ReturnEntity())($method);
 
-        $this->assertSame(null, $entity->type);
+        $this->assertSame(null, $entity);
     }
 
     public function testReturnArray(): void
     {
         $method = new ReflectionMethod(new FakeReturn(), 'returnArray');
-        $entity = new ReturnEntity($method);
+        $entity = (new ReturnEntity())($method);
 
-        $this->assertSame(null, $entity->type);
+        $this->assertSame(null, $entity);
     }
 }

--- a/tests/ReturnTypeTest.php
+++ b/tests/ReturnTypeTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+
+use PHPUnit\Framework\TestCase;
+use Ray\MediaQuery\Entity\FakeEntity;
+use ReflectionMethod;
+
+class Foo
+{
+}
+class ReturnTypeTest extends TestCase
+{
+    public function testReturnItem(): void
+    {
+        $method = new ReflectionMethod(new FakeReturn(), 'item');
+        $entity = new ReturnEntity($method);
+
+        $this->assertSame(FakeEntity::class, $entity->type);
+    }
+
+    public function testReturnList(): void
+    {
+        $method = new ReflectionMethod(new FakeReturn(), 'list');
+        $entity = new ReturnEntity($method);
+
+        $this->assertSame(FakeEntity::class, $entity->type);
+    }
+}

--- a/tests/SqlQueryTest.php
+++ b/tests/SqlQueryTest.php
@@ -95,7 +95,11 @@ class SqlQueryTest extends TestCase
         return $pages;
     }
 
-    /** @depends testPager */
+    /**
+     * @param Pages<mixed> $pages
+     *
+     * @depends testPager
+     */
     public function testPagerCount(Pages $pages): void
     {
         $this->assertSame(2, count($pages));
@@ -136,20 +140,32 @@ class SqlQueryTest extends TestCase
         $this->assertInstanceOf(PDOStatement::class, $sqlQuery->getStatement());
     }
 
-    /** @depends testPager */
+    /**
+     * @param Pages<mixed> $pages
+     *
+     * @depends testPager
+     */
     public function testOffsetExists(Pages $pages): void
     {
         $this->assertTrue(isset($pages[1]));
     }
 
-    /** @depends testPager */
+    /**
+     * @param Pages<mixed> $pages
+     *
+     * @depends testPager
+     */
     public function testOffsetSet(Pages $pages): void
     {
         $this->expectException(LogicException::class);
         $pages[1] = '';
     }
 
-    /** @depends testPager */
+    /**
+     * @param Pages<mixed> $pages
+     *
+     * @depends testPager
+     */
     public function testOffsetUnset(Pages $pages): void
     {
         $this->expectException(LogicException::class);


### PR DESCRIPTION
戻り値のエンティティの型を尊重します。

戻り値がエンティティの型の時に`entity:`の指定と、リストまたはアイテムの指定（`type: 'row'`または`type: 'row_list'`）が不要になります。

The `entity:` specification and the list or item specification (`type: 'row'` or `type: 'row_list'`) are no longer required when the return value is of type entity.

```php
interface TodoInterface
{
    #[DbQuery('todo_item')]
    public function item(string $id): Todo;　　// type=row

    #[DbQuery('todo_list')]
    /**　@return array<Todo>　*/
    public function list(): array; // type=row_list
}
```

エンティティを利用したページングの場合には`Page`にジェネリクスでエンティティクラスを指定します。

For entity-based paging, specify the entity class in generics for `Page`.

```php
interface TodoPagerInterface
{
    #[DbQuery('todo_list'), Pager(perPage: 10, template: '/{?page}')]
    /**　@return Pages<Todo>　*/
    public function __invoke(): Pages;
}
```

以前は以下のような矛盾した表記が可能でした。（エンティティがFooなのに関数の戻り値はBar）

Previously, the following contradictory notations were possible
```php
interface TodoInterface
{
    #[DbQuery('todo_item', entity: Foo::class)]
    public function item(string $id): Bar
}
```

https://github.com/ray-di/Ray.MediaQuery/blob/return_entity/UPGRADE.ja.md
