### PR TITLE
Support for array type in ParamConverter

### DIFF
--- a/src/ToScalarInterface.php
+++ b/src/ToScalarInterface.php
@@ -6,5 +6,6 @@ namespace Ray\MediaQuery;
 
 interface ToScalarInterface
 {
-    public function toScalar(): bool|string|int|float;
+    /** @return scalar|array<scalar> */
+    public function toScalar(): bool|string|int|float|array;
 }

--- a/tests/Fake/FakeArray.php
+++ b/tests/Fake/FakeArray.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Ray\MediaQuery;
+
+class FakeArray implements ToScalarInterface
+{
+    /** @return array<int> */
+    public function toScalar(): array
+    {
+        return [0, 1];
+    }
+}

--- a/tests/ParamConverterTest.php
+++ b/tests/ParamConverterTest.php
@@ -12,9 +12,19 @@ class ParamConverterTest extends TestCase
 {
     public function testInvoke(): void
     {
-        $values = ['date_val' => new UnixEpocTime(), 'bool_val' => new FakeBool(), 'string_val' => new FakeString()];
+        $values = [
+            'date_val' => new UnixEpocTime(),
+            'bool_val' => new FakeBool(),
+            'string_val' => new FakeString(),
+            'array_val' => new FakeArray(),
+        ];
         (new ParamConverter())($values);
-        $this->assertSame(['date_val' => UnixEpocTime::TEXT, 'bool_val' => true, 'string_val' => 'a'], $values);
+        $this->assertSame([
+            'date_val' => UnixEpocTime::TEXT,
+            'bool_val' => true,
+            'string_val' => 'a',
+            'array_val' => [0, 1],
+        ], $values);
     }
 
     public function testInvalidParam(): void


### PR DESCRIPTION
* Arura.Sqlの [Array Quoting](https://github.com/auraphp/Aura.Sql/blob/5.x/docs/getting-started.md#array-quoting) に対応するためにParamConverterが配列を扱えるように変更しました。
* インターフェイスの名前は ToScalarInterface となっておりarrayだとスカラーとは厳密には呼べないですが、後方互換性を考えてそのままにしてあります。 ToPrimitiveInterface::toPrimitive にすると名前的にも良さそうですが・・・。

例）
```sql
SELECT * FROM article WHERE status IN (:status)
```

```php
<?php
interface ArticleInterface
{
    #[DbQuery(id: 'article_list')]
    public function list(StatusList $status): array;
}
```

```php
<?php

readonly class StatusList implements ToScalarInterface
{
    public function __construct(private array $statusList)
    {
    }

    public function toScalar(): array
    {
        return $this->statusList;
    }
}
```

```php
<?php

$articles = $this->article->list(new StatusList(['draft', 'public']));
```

案2)
ToScalarList インターフェイスを新設

```php
<?php
interface ToScalarListInterface
{
    /** @return array<scalar> */
    public function toScalarList(): array;
}


readonly class StatusList implements ToScalarListInterface
{
    public function __construct(private array $statusList)
    {
    }

    public function toScalarList(): array
    {
        return $this->statusList;
    }
}
```