### PR TITLE
Support nullable param in ParamInjector

### DIFF
--- a/src/ParamInjector.php
+++ b/src/ParamInjector.php
@@ -37,7 +37,8 @@ final class ParamInjector implements ParamInjectorInterface
         foreach ($parameters as $parameter) {
             $pos = $parameter->getPosition();
             /** @psalm-suppress MixedAssignment */
-            $namedArgs[$parameter->getName()] = $args[$pos] ?? $this->getInjectedParam($parameter);
+            $namedArgs[$parameter->getName()] = array_key_exists($pos, $args)
+                ? $args[$pos] : $this->getInjectedParam($parameter);
         }
 
         return $namedArgs;

--- a/tests/FakeParamInjectMethod.php
+++ b/tests/FakeParamInjectMethod.php
@@ -12,7 +12,7 @@ class FakeParamInjectMethod
     {
     }
 
-    public function paramInject(DateTimeInterface|null $dateTime = null): void
+    public function paramInject(string|null $nullableString, DateTimeInterface|null $dateTime = null): void
     {
     }
 

--- a/tests/ParamInjectorTest.php
+++ b/tests/ParamInjectorTest.php
@@ -33,7 +33,7 @@ class ParamInjectorTest extends TestCase
 
     public function testGetArgumentes(): void
     {
-        $namedArgs = $this->injector->getArgumentes(new ReflectiveMethodInvocation(new FakeParamInjectMethod(), 'paramInject', []));
+        $namedArgs = $this->injector->getArgumentes(new ReflectiveMethodInvocation(new FakeParamInjectMethod(), 'paramInject', [null]));
         $this->assertInstanceOf(DateTimeImmutable::class, $namedArgs['dateTime']);
     }
 


### PR DESCRIPTION
Nullable引数が存在していると意図せずParamInjectorが動作してしまう問題を修正しました。