### PR TITLE
Reorder conversion methods in ParamConverter and binary check for logging

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     "require": {
         "php": "^8.1",
         "ext-pdo": "*",
+        "ext-mbstring": "*",
         "aura/sql": "^4.0 || ^5.0",
         "doctrine/annotations": "^1.12 || ^2.0",
         "guzzlehttp/guzzle": "^6.3 || ^7.2",

--- a/src/MediaQueryLogger.php
+++ b/src/MediaQueryLogger.php
@@ -6,8 +6,10 @@ namespace Ray\MediaQuery;
 
 use Stringable;
 
+use function base64_encode;
 use function implode;
 use function json_encode;
+use function mb_check_encoding;
 use function sprintf;
 
 use const JSON_THROW_ON_ERROR;
@@ -27,6 +29,14 @@ final class MediaQueryLogger implements MediaQueryLoggerInterface, Stringable
      */
     public function log(string $queryId, array $values): void
     {
+        foreach ($values as &$value) {
+            if (mb_check_encoding($value, 'UTF-8')) {
+                continue;
+            }
+
+            $value = base64_encode($value); // or '(binary) ' . base64_encode($value); // or '(binary) ' .
+        }
+
         $this->logs[] = sprintf('query: %s(%s)', $queryId, json_encode($values, JSON_THROW_ON_ERROR));
     }
 

--- a/src/MediaQueryLogger.php
+++ b/src/MediaQueryLogger.php
@@ -36,7 +36,7 @@ final class MediaQueryLogger implements MediaQueryLoggerInterface, Stringable
                 continue;
             }
 
-            $value = base64_encode($value); // or '(binary) ' . base64_encode($value); // or '(binary) ' .
+            $value = base64_encode($value); // Encode non-UTF-8 strings in base64 to handle binary data.
         }
 
         $this->logs[] = sprintf('query: %s(%s)', $queryId, json_encode($values, JSON_THROW_ON_ERROR));

--- a/src/MediaQueryLogger.php
+++ b/src/MediaQueryLogger.php
@@ -8,6 +8,7 @@ use Stringable;
 
 use function base64_encode;
 use function implode;
+use function is_string;
 use function json_encode;
 use function mb_check_encoding;
 use function sprintf;
@@ -29,8 +30,9 @@ final class MediaQueryLogger implements MediaQueryLoggerInterface, Stringable
      */
     public function log(string $queryId, array $values): void
     {
+        /** @psalm-suppress MixedAssignment */
         foreach ($values as &$value) {
-            if (mb_check_encoding($value, 'UTF-8')) {
+            if (! is_string($value) || mb_check_encoding($value, 'UTF-8')) {
                 continue;
             }
 

--- a/src/ParamConverter.php
+++ b/src/ParamConverter.php
@@ -35,13 +35,13 @@ final class ParamConverter implements ParamConverterInterface
                 continue;
             }
 
-            if (method_exists($value, '__toString')) {
-                $value = (string) $value;
+            if ($value instanceof ToScalarInterface) {
+                $value = $value->toScalar();
                 continue;
             }
 
-            if ($value instanceof ToScalarInterface) {
-                $value = $value->toScalar();
+            if (method_exists($value, '__toString')) {
+                $value = (string) $value;
                 continue;
             }
 


### PR DESCRIPTION

Close #57 

## BC Berak

This PR breaks backwards compatibility ( even though it is minor) as it changes the order of processing in ParamConverter. The release is incremented by the minor version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the logging mechanism to include encoding of values for better data integrity and security.
- **Bug Fixes**
	- Improved parameter conversion logic by optimizing the order of checks, enhancing the handling and conversion of data types.
- **Chores**
	- Updated system requirements to include the `ext-mbstring` PHP extension for better multilingual support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->