### PR TITLE
Enable PHP 8.4 comat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "php": "^8.1",
         "ext-pdo": "*",
         "ext-mbstring": "*",
+        "ext-tokenizer": "*",
         "aura/sql": "^4.0 || ^5.0",
         "doctrine/annotations": "^1.12 || ^2.0",
         "guzzlehttp/guzzle": "^6.3 || ^7.2",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
         "ray/aop": "^2.10.4",
         "ray/aura-sql-module": "^1.12.0",
         "ray/di": "^2.14",
-        "roave/better-reflection": "^4.12 || ^5.6 || ^6.25",
         "symfony/polyfill-php81": "^1.24"
     },
     "require-dev": {

--- a/src/ClassesInDirectories.php
+++ b/src/ClassesInDirectories.php
@@ -40,20 +40,13 @@ final class ClassesInDirectories
 
             /** @psalm-suppress MixedAssignment */
             foreach ($iterator as $file) {
-                if (! $file instanceof SplFileInfo) {
-                    continue;
-                }
-
-                if ($file->getExtension() !== 'php') {
+                if (! $file instanceof SplFileInfo || $file->getExtension() !== 'php') {
                     continue;
                 }
 
                 $className = self::getClassFromFile($file->getRealPath());
-                if ($className === null) {
-                    continue;
-                }
 
-                if (! class_exists($className) && ! interface_exists($className)) {
+                if ($className === null || ! class_exists($className) && ! interface_exists($className)) {
                     continue;
                 }
 

--- a/src/ClassesInDirectories.php
+++ b/src/ClassesInDirectories.php
@@ -14,6 +14,8 @@ use function class_exists;
 use function count;
 use function file_get_contents;
 use function interface_exists;
+use function is_array;
+use function is_string;
 use function token_get_all;
 
 use const T_CLASS;
@@ -69,41 +71,65 @@ final class ClassesInDirectories
             return null;
         }
 
-        $namespace = '';
-        $class = '';
         $tokens = token_get_all($content);
-        $count = count($tokens);
+        /** @var array<int, mixed> $tokens */
 
-        for ($i = 0; $i < $count; $i++) {
-            if (! isset($tokens[$i][0])) {
-                continue;
-            }
+        $namespace = self::extractNamespace($tokens);
+        $class = self::extractClassName($tokens);
 
-            if ($tokens[$i][0] === T_NAMESPACE) {
-                for ($j = $i + 1; $j < $count; $j++) {
-                    if ($tokens[$j][0] === T_NAME_QUALIFIED) {
-                        $namespace = $tokens[$j][1];
-                        break;
-                    }
-                }
-            }
-
-            if ($tokens[$i][0] !== T_CLASS && $tokens[$i][0] !== T_INTERFACE) {
-                continue;
-            }
-
-            for ($j = $i + 1; $j < $count; $j++) {
-                if ($tokens[$j][0] === T_STRING) {
-                    $class = $tokens[$j][1];
-                    break 2;
-                }
-            }
-        }
-
-        if ($class === '') {
+        if ($class === null) {
             return null;
         }
 
-        return $namespace ? $namespace . '\\' . $class : $class;
+        if ($namespace === null) {
+            return $class;
+        }
+
+        return $namespace . '\\' . $class;
+    }
+
+    /** @param array<int, mixed> $tokens*/
+    private static function extractNamespace(array $tokens): string|null
+    {
+        /** @psalm-suppress MixedAssignment */
+        foreach ($tokens as $index => $token) {
+            if (is_array($token) && $token[0] !== T_NAMESPACE) {
+                continue;
+            }
+
+            for ($j = $index + 1, $count = count($tokens); $j < $count; $j++) {
+                assert(is_array($tokens[$j]) && isset($tokens[$j][0]));
+                if ($tokens[$j][0] === T_NAME_QUALIFIED) {
+                    $string = $tokens[$j][1];
+                    assert(is_string($string));
+
+                    return $string;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /** @param array<int, mixed> $tokens */
+    private static function extractClassName(array $tokens): string|null
+    {
+        foreach ($tokens as $index => $token) {
+            assert(is_array($token));
+            if ($token[0] !== T_CLASS && $token[0] !== T_INTERFACE) {
+                continue;
+            }
+
+            for ($j = $index + 1, $count = count($tokens); $j < $count; $j++) {
+                if (is_array($tokens[$j]) && $tokens[$j][0] === T_STRING) {
+                    $string = $tokens[$j][1];
+                    assert(is_string($string));
+
+                    return $string;
+                }
+            }
+        }
+
+        return null;
     }
 }

--- a/src/ClassesInDirectories.php
+++ b/src/ClassesInDirectories.php
@@ -9,17 +9,30 @@ use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use SplFileInfo;
 
+use function class_exists;
+use function count;
+use function file_get_contents;
+use function interface_exists;
+use function token_get_all;
+
+use const T_CLASS;
+use const T_INTERFACE;
+use const T_NAME_QUALIFIED;
+use const T_NAMESPACE;
+use const T_STRING;
+
 final class ClassesInDirectories
 {
     /**
      * @param list<string> $directories
+     *
      * @return Generator<int, class-string>
      */
     public static function list(string ...$directories): Generator
     {
         foreach ($directories as $directory) {
             $iterator = new RecursiveIteratorIterator(
-                new RecursiveDirectoryIterator($directory)
+                new RecursiveDirectoryIterator($directory),
             );
 
             foreach ($iterator as $file) {
@@ -36,14 +49,16 @@ final class ClassesInDirectories
                     continue;
                 }
 
-                if (class_exists($className) || interface_exists($className)) {
-                    yield $className;
+                if (! class_exists($className) && ! interface_exists($className)) {
+                    continue;
                 }
+
+                yield $className;
             }
         }
     }
 
-    private static function getClassFromFile(string $filePath): ?string
+    private static function getClassFromFile(string $filePath): string|null
     {
         $content = file_get_contents($filePath);
         if ($content === false) {
@@ -56,7 +71,7 @@ final class ClassesInDirectories
         $count = count($tokens);
 
         for ($i = 0; $i < $count; $i++) {
-            if (!isset($tokens[$i][0])) {
+            if (! isset($tokens[$i][0])) {
                 continue;
             }
 
@@ -69,12 +84,14 @@ final class ClassesInDirectories
                 }
             }
 
-            if ($tokens[$i][0] === T_CLASS || $tokens[$i][0] === T_INTERFACE) {
-                for ($j = $i + 1; $j < $count; $j++) {
-                    if ($tokens[$j][0] === T_STRING) {
-                        $class = $tokens[$j][1];
-                        break 2;
-                    }
+            if ($tokens[$i][0] !== T_CLASS && $tokens[$i][0] !== T_INTERFACE) {
+                continue;
+            }
+
+            for ($j = $i + 1; $j < $count; $j++) {
+                if ($tokens[$j][0] === T_STRING) {
+                    $class = $tokens[$j][1];
+                    break 2;
                 }
             }
         }

--- a/src/ClassesInDirectories.php
+++ b/src/ClassesInDirectories.php
@@ -9,6 +9,7 @@ use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use SplFileInfo;
 
+use function assert;
 use function class_exists;
 use function count;
 use function file_get_contents;
@@ -53,7 +54,9 @@ final class ClassesInDirectories
                 if (! class_exists($className) && ! interface_exists($className)) {
                     continue;
                 }
+
                 assert(class_exists($className) || interface_exists($className));
+
                 yield $className;
             }
         }

--- a/src/ClassesInDirectories.php
+++ b/src/ClassesInDirectories.php
@@ -98,7 +98,8 @@ final class ClassesInDirectories
             }
 
             for ($j = $index + 1, $count = count($tokens); $j < $count; $j++) {
-                if ($tokens[$j][0] === T_NAME_QUALIFIED) {
+                if (isset($tokens[$j][0]) && $tokens[$j][0] === T_NAME_QUALIFIED) { // @phpstan-ignore-line
+                    assert(isset($tokens[$j][1])); // @phpstan-ignore-line
                     $string = $tokens[$j][1];
                     assert(is_string($string));
 
@@ -113,8 +114,9 @@ final class ClassesInDirectories
     /** @param array<int, mixed> $tokens */
     private static function extractClassName(array $tokens): string|null
     {
+        /** @psalm-suppress MixedAssignment */
         foreach ($tokens as $index => $token) {
-            if ($token[0] !== T_CLASS && $token[0] !== T_INTERFACE) {
+            if (isset($token[0]) && $token[0] !== T_CLASS && $token[0] !== T_INTERFACE) { // @phpstan-ignore-line
                 continue;
             }
 

--- a/src/ClassesInDirectories.php
+++ b/src/ClassesInDirectories.php
@@ -5,51 +5,84 @@ declare(strict_types=1);
 namespace Ray\MediaQuery;
 
 use Generator;
-use Roave\BetterReflection\BetterReflection;
-use Roave\BetterReflection\Reflector\DefaultReflector;
-use Roave\BetterReflection\SourceLocator\Type\AggregateSourceLocator;
-use Roave\BetterReflection\SourceLocator\Type\AutoloadSourceLocator;
-use Roave\BetterReflection\SourceLocator\Type\DirectoriesSourceLocator;
-
-use function assert;
-use function class_exists;
-use function interface_exists;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
 
 final class ClassesInDirectories
 {
     /**
-     * get a list of all classes in the given directories.
-     *
-     * Based on: https://github.com/Roave/BetterReflection/blob/396a07c9d276cb9ffba581b24b2dadbb542d542e/demo/parsing-whole-directory/example2.php.
-     *
      * @param list<string> $directories
-     *
      * @return Generator<int, class-string>
-     *
-     * This function code is taken from https://github.com/WyriHaximus/php-list-classes-in-directory/blob/master/src/functions.php
-     * and modified for roave/better-reflection 5.x
-     *
-     * @see https://github.com/WyriHaximus/php-list-classes-in-directory
-     * @psalm-suppress MixedReturnTypeCoercion
-     * @phpstan-ignore-next-line/
      */
-    public static function list(string ...$directories): iterable
+    public static function list(string ...$directories): Generator
     {
-        /** @var list<string> $directories */
-        $sourceLocator = new AggregateSourceLocator([
-            new DirectoriesSourceLocator(
-                $directories,
-                (new BetterReflection())->astLocator(),
-            ),
-            // ↓ required to autoload parent classes/interface from another directory than /src (e.g. /vendor)
-            new AutoloadSourceLocator((new BetterReflection())->astLocator()),
-        ]);
+        foreach ($directories as $directory) {
+            $iterator = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($directory)
+            );
 
-        foreach ((new DefaultReflector($sourceLocator))->reflectAllClasses() as $class) {
-            $className = $class->getName();
-            assert(class_exists($className) || interface_exists($className));
+            foreach ($iterator as $file) {
+                if (! $file instanceof SplFileInfo) {
+                    continue;
+                }
 
-            yield $className;
+                if ($file->getExtension() !== 'php') {
+                    continue;
+                }
+
+                $className = self::getClassFromFile($file->getRealPath());
+                if ($className === null) {
+                    continue;
+                }
+
+                if (class_exists($className) || interface_exists($className)) {
+                    yield $className;
+                }
+            }
         }
+    }
+
+    private static function getClassFromFile(string $filePath): ?string
+    {
+        $content = file_get_contents($filePath);
+        if ($content === false) {
+            return null;
+        }
+
+        $namespace = '';
+        $class = '';
+        $tokens = token_get_all($content);
+        $count = count($tokens);
+
+        for ($i = 0; $i < $count; $i++) {
+            if (!isset($tokens[$i][0])) {
+                continue;
+            }
+
+            if ($tokens[$i][0] === T_NAMESPACE) {
+                for ($j = $i + 1; $j < $count; $j++) {
+                    if ($tokens[$j][0] === T_NAME_QUALIFIED) {
+                        $namespace = $tokens[$j][1];
+                        break;
+                    }
+                }
+            }
+
+            if ($tokens[$i][0] === T_CLASS || $tokens[$i][0] === T_INTERFACE) {
+                for ($j = $i + 1; $j < $count; $j++) {
+                    if ($tokens[$j][0] === T_STRING) {
+                        $class = $tokens[$j][1];
+                        break 2;
+                    }
+                }
+            }
+        }
+
+        if ($class === '') {
+            return null;
+        }
+
+        return $namespace ? $namespace . '\\' . $class : $class;
     }
 }

--- a/src/ClassesInDirectories.php
+++ b/src/ClassesInDirectories.php
@@ -28,13 +28,14 @@ final class ClassesInDirectories
      *
      * @return Generator<int, class-string>
      */
-    public static function list(string ...$directories): Generator
+    public static function list(string ...$directories): Generator // @phpstan-ignore-line
     {
         foreach ($directories as $directory) {
             $iterator = new RecursiveIteratorIterator(
                 new RecursiveDirectoryIterator($directory),
             );
 
+            /** @psalm-suppress MixedAssignment */
             foreach ($iterator as $file) {
                 if (! $file instanceof SplFileInfo) {
                     continue;
@@ -52,7 +53,7 @@ final class ClassesInDirectories
                 if (! class_exists($className) && ! interface_exists($className)) {
                     continue;
                 }
-
+                assert(class_exists($className) || interface_exists($className));
                 yield $className;
             }
         }

--- a/src/ClassesInDirectories.php
+++ b/src/ClassesInDirectories.php
@@ -27,11 +27,11 @@ use const T_STRING;
 final class ClassesInDirectories
 {
     /**
-     * @param list<string> $directories
+    +     * @param string ...$directories
      *
      * @return Generator<int, class-string>
      */
-    public static function list(string ...$directories): Generator // @phpstan-ignore-line
+    public static function list(string ...$directories): Generator
     {
         foreach ($directories as $directory) {
             $iterator = new RecursiveIteratorIterator(
@@ -56,8 +56,6 @@ final class ClassesInDirectories
                 if (! class_exists($className) && ! interface_exists($className)) {
                     continue;
                 }
-
-                assert(class_exists($className) || interface_exists($className));
 
                 yield $className;
             }

--- a/src/ClassesInDirectories.php
+++ b/src/ClassesInDirectories.php
@@ -98,7 +98,6 @@ final class ClassesInDirectories
             }
 
             for ($j = $index + 1, $count = count($tokens); $j < $count; $j++) {
-                assert(is_array($tokens[$j]) && isset($tokens[$j][0]));
                 if ($tokens[$j][0] === T_NAME_QUALIFIED) {
                     $string = $tokens[$j][1];
                     assert(is_string($string));
@@ -115,7 +114,6 @@ final class ClassesInDirectories
     private static function extractClassName(array $tokens): string|null
     {
         foreach ($tokens as $index => $token) {
-            assert(is_array($token));
             if ($token[0] !== T_CLASS && $token[0] !== T_INTERFACE) {
                 continue;
             }


### PR DESCRIPTION
Added PHP 8.4 as the current stable version while moving PHP 8.3 to the list of old stable versions. This change ensures the CI system tests against the latest PHP version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced class discovery functionality by modifying the `list` method to yield class names directly.
	- Introduced new methods for extracting class names from PHP files.

- **Bug Fixes**
	- Removed reliance on an external dependency, streamlining the class discovery process.

- **Documentation**
	- Updated docblock comments to simplify documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->