### PR TITLE
Set PHP version constraint to >=8.1 <8.4 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": ">=8.1 <8.4",
         "ext-mbstring": "*",
         "ext-pdo": "*",
         "ext-tokenizer": "*",


### PR DESCRIPTION
Updated the PHP requirement in composer.json to explicitly limit compatibility to versions between 8.1 and 8.4. This change ensures the project runs in the tested PHP range, preventing potential issues with future versions.

## Summary by Sourcery

Build:
- Sets PHP version constraint to >=8.1 <8.4 in composer.json.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Adjusted PHP version support to ensure compatibility with versions 8.1 through 8.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->