### PR TITLE
Fix SELECT query detection to handle comments and edge cases properly

### DIFF
--- a/src/SqlQuery.php
+++ b/src/SqlQuery.php
@@ -45,7 +45,7 @@ final class SqlQuery implements SqlQueryInterface
     // \s* : Skip final whitespace
     // (SELECT|WITH) : Capture SELECT or WITH keywords (read-only queries)
     // i : Case insensitive
-    private const SELECT_QUERY_PATTERN = '/^\s*(?:\/\*.*?\*\/\s*|--.*?[\r\n]\s*)*\s*(SELECT|WITH)/i';
+    private const SELECT_QUERY_PATTERN = '/^\s*(?:\/\*.*?\*\/\s*|--.*?(?:[\r\n]|$)\s*)*\s*(SELECT|WITH)/i';
 
     private PDOStatement|null $pdoStatement = null;
 

--- a/src/SqlQuery.php
+++ b/src/SqlQuery.php
@@ -45,7 +45,7 @@ final class SqlQuery implements SqlQueryInterface
     // \s* : Skip final whitespace
     // (SELECT|WITH) : Capture SELECT or WITH keywords (read-only queries)
     // i : Case insensitive
-    private const SELECT_QUERY_PATTERN = '/^\s*(?:\/\*.*?\*\/\s*|--.*?(?:[\r\n]|$)\s*)*\s*(SELECT|WITH)/i';
+    private const SELECT_QUERY_PATTERN = '/^\s*(?:(?:--[^\r\n]*|\/\*.*?\*\/|\(+)\s*)*(SELECT|WITH)\b/is';
 
     private PDOStatement|null $pdoStatement = null;
 

--- a/src/SqlQuery.php
+++ b/src/SqlQuery.php
@@ -154,6 +154,8 @@ final class SqlQuery implements SqlQueryInterface
             $sqls .= ';';
         }
 
+        $sqls = preg_replace('/^\s*--.*$/m', '', $sqls);
+
         $sqls = explode(';', trim($sqls, "\\ \t\n\r\0\x0B"));
         array_pop($sqls);
         if ($sqls[0] === '') {

--- a/src/SqlQuery.php
+++ b/src/SqlQuery.php
@@ -25,9 +25,8 @@ use function file_get_contents;
 use function is_array;
 use function is_object;
 use function json_encode;
-use function preg_replace;
+use function preg_match;
 use function sprintf;
-use function stripos;
 use function strpos;
 use function trim;
 
@@ -35,7 +34,18 @@ use const JSON_THROW_ON_ERROR;
 
 final class SqlQuery implements SqlQueryInterface
 {
-    private const C_STYLE_COMMENT = '/\/\*(.*?)\*\//u';
+    // Pattern to detect SELECT queries by skipping comments and finding the first SQL keyword
+    // ^ : Start from beginning of string
+    // \s* : Skip leading whitespace
+    // (?:...)* : Non-capturing group repeated 0 or more times (comment blocks)
+    //   \/\*.*?\*\/ : C-style comment /* ... */
+    //   | : OR operator
+    //   --.*?[\r\n] : Hyphen comment -- to end of line
+    //   \s* : Skip whitespace after comments
+    // \s* : Skip final whitespace
+    // (SELECT|WITH) : Capture SELECT or WITH keywords (read-only queries)
+    // i : Case insensitive
+    private const SELECT_QUERY_PATTERN = '/^\s*(?:\/\*.*?\*\/\s*|--.*?[\r\n]\s*)*\s*(SELECT|WITH)/i';
 
     private PDOStatement|null $pdoStatement = null;
 
@@ -122,8 +132,7 @@ final class SqlQuery implements SqlQueryInterface
 
         $this->pdoStatement = $pdoStatement;
         $lastQuery = $pdoStatement->queryString;
-        $query = trim((string) preg_replace(self::C_STYLE_COMMENT, '', $lastQuery));
-        $isSelect = stripos($query, 'select') === 0 || stripos($query, 'with') === 0;
+        $isSelect = (bool) preg_match(self::SELECT_QUERY_PATTERN, $lastQuery);
         $result = $isSelect ? $this->fetchAll($pdoStatement, $fetch) : [];
         /** @var array<string, mixed> $values */
         $this->logger->log($sqlId, $values);
@@ -153,8 +162,6 @@ final class SqlQuery implements SqlQueryInterface
         if (strpos($sqls, ';') === false) {
             $sqls .= ';';
         }
-
-        $sqls = (string) preg_replace('/^\s*--.*$/m', '', $sqls);
 
         $sqls = explode(';', trim($sqls, "\\ \t\n\r\0\x0B"));
         array_pop($sqls);

--- a/src/SqlQuery.php
+++ b/src/SqlQuery.php
@@ -154,7 +154,7 @@ final class SqlQuery implements SqlQueryInterface
             $sqls .= ';';
         }
 
-        $sqls = preg_replace('/^\s*--.*$/m', '', $sqls);
+        $sqls = (string) preg_replace('/^\s*--.*$/m', '', $sqls);
 
         $sqls = explode(';', trim($sqls, "\\ \t\n\r\0\x0B"));
         array_pop($sqls);

--- a/tests/SqlQueryTest.php
+++ b/tests/SqlQueryTest.php
@@ -80,6 +80,13 @@ class SqlQueryTest extends TestCase
         $this->assertSame([0 => $this->insertData], $result);
     }
 
+    /** @depends testExec */
+    public function testHyphenComment(): void
+    {
+        $result = $this->sqlQuery->getRow('todo_item_hyphen_comment', ['id' => '1']);
+        $this->assertSame($this->insertData, $result);
+    }
+
     public function testPager(): PagesInterface
     {
         $walkTodo = ['id' => '2', 'title' => 'walk'];

--- a/tests/sql/todo_item_hyphen_comment.sql
+++ b/tests/sql/todo_item_hyphen_comment.sql
@@ -1,2 +1,4 @@
--- comment
-SELECT * FROM todo WHERE id = :id;
+-- comment 1
+-- comment 2
+SELECT * FROM todo WHERE id = :id; -- comment 3
+-- comment 4

--- a/tests/sql/todo_item_hyphen_comment.sql
+++ b/tests/sql/todo_item_hyphen_comment.sql
@@ -1,0 +1,2 @@
+-- comment
+SELECT * FROM todo WHERE id = :id;

--- a/tests/sql/todo_item_hyphen_comment.sql
+++ b/tests/sql/todo_item_hyphen_comment.sql
@@ -1,4 +1,2 @@
--- comment 1
--- comment 2
-SELECT * FROM todo WHERE id = :id; -- comment 3
--- comment 4
+-- comment
+SELECT * FROM todo WHERE id = :id;


### PR DESCRIPTION
## Overview
- Improve SELECT query detection to skip both C-style `/* comment */` and hyphen comments `-- comment`

## Summary by Sourcery

Improve SELECT query detection to skip both C-style and hyphen comments by using a unified regex pattern and add tests for hyphen comment support.

Bug Fixes:
- Properly ignore SQL lines starting with '--' when detecting read-only queries to prevent misclassification.

Enhancements:
- Replace manual comment stripping and prefix checks with a SELECT_QUERY_PATTERN that skips both C-style and hyphen comments before matching SELECT or WITH.

Tests:
- Add testHyphenComment and SQL fixture to verify handling of queries surrounded by hyphen comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced detection of SELECT queries to accurately handle queries with leading comments, including C-style and single-line comments.

- **Tests**
  - Added tests to verify handling of SQL queries with single-line comments.
  - Introduced a new SQL test file covering queries with hyphen-style comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->