### PR TITLE
Update ray/input-query dependency to ^1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.1] - 2025-07-30
+
+### Changed
+- Update ray/input-query dependency to ^1.0
+
 ## [0.17.0] - 2025-07-07
 
 ### Added
@@ -99,6 +104,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Please refer to the git history for changes in earlier versions.
 
+[0.17.1]: https://github.com/ray-di/Ray.MediaQuery/compare/0.17.0...0.17.1
 [0.17.0]: https://github.com/ray-di/Ray.MediaQuery/compare/0.16.0...0.17.0
 [0.16.0]: https://github.com/ray-di/Ray.MediaQuery/compare/0.15.1...0.16.0
 [0.15.1]: https://github.com/ray-di/Ray.MediaQuery/compare/0.15.0...0.15.1

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ray/aop": "^2.10.4",
         "ray/aura-sql-module": "^1.12.0",
         "ray/di": "^2.14",
-        "ray/input-query": "^0.2.0",
+        "ray/input-query": "^1.0",
         "symfony/polyfill-php81": "^1.24",
         "symfony/polyfill-php83": "^1.32"
     },


### PR DESCRIPTION
## Summary
- Update ray/input-query dependency from ^0.2.0 to ^1.0
- Update CHANGELOG.md for version 0.17.1 release

## Test plan
- [ ] Run `composer tests` to ensure all tests pass
- [ ] Verify compatibility with the updated dependency

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Bump the ray/input-query dependency to version ^1.0 and prepare the 0.17.1 release

Enhancements:
- Update ray/input-query requirement in composer.json to ^1.0

Documentation:
- Add 0.17.1 entry to CHANGELOG.md with updated comparison link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the dependency on ray/input-query to version ^1.0.
  * Added a changelog entry for version 0.17.1 documenting this update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->