### PR TITLE
Fix line comment handling in query type detection

### DIFF
--- a/src/SqlQuery.php
+++ b/src/SqlQuery.php
@@ -36,6 +36,7 @@ use const JSON_THROW_ON_ERROR;
 final class SqlQuery implements SqlQueryInterface
 {
     private const C_STYLE_COMMENT = '/\/\*(.*?)\*\//u';
+    private const LINE_COMMENT = '/--[^\r\n]*/';
 
     private PDOStatement|null $pdoStatement = null;
 
@@ -123,8 +124,10 @@ final class SqlQuery implements SqlQueryInterface
 
         $this->pdoStatement = $pdoStatement;
         $lastQuery = $pdoStatement->queryString;
-        $query = trim((string) preg_replace(self::C_STYLE_COMMENT, '', $lastQuery));
-        $isSelect = stripos($query, 'select') === 0 || stripos($query, 'with') === 0;
+        // Remove comments only for query type detection, not for execution
+        $queryForDetection = (string) preg_replace(self::C_STYLE_COMMENT, '', $lastQuery);
+        $queryForDetection = trim((string) preg_replace(self::LINE_COMMENT, '', $queryForDetection));
+        $isSelect = stripos($queryForDetection, 'select') === 0 || stripos($queryForDetection, 'with') === 0;
         $result = $isSelect ? $this->fetchAll($pdoStatement, $fetch) : [];
         /** @var array<string, mixed> $values */
         $this->logger->log($sqlId, $values);

--- a/src/SqlQuery.php
+++ b/src/SqlQuery.php
@@ -36,7 +36,7 @@ use const JSON_THROW_ON_ERROR;
 final class SqlQuery implements SqlQueryInterface
 {
     private const C_STYLE_COMMENT = '/\/\*(.*?)\*\//u';
-    private const LINE_COMMENT = '/--[^\r\n]*/';
+    private const LINE_COMMENT = '/^\s*--[^\r\n]*/m';
 
     private PDOStatement|null $pdoStatement = null;
 
@@ -124,9 +124,7 @@ final class SqlQuery implements SqlQueryInterface
 
         $this->pdoStatement = $pdoStatement;
         $lastQuery = $pdoStatement->queryString;
-        // Remove comments only for query type detection, not for execution
-        $queryForDetection = (string) preg_replace(self::C_STYLE_COMMENT, '', $lastQuery);
-        $queryForDetection = trim((string) preg_replace(self::LINE_COMMENT, '', $queryForDetection));
+        $queryForDetection = $this->removeCommentsForDetection($lastQuery);
         $isSelect = stripos($queryForDetection, 'select') === 0 || stripos($queryForDetection, 'with') === 0;
         $result = $isSelect ? $this->fetchAll($pdoStatement, $fetch) : [];
         /** @var array<string, mixed> $values */
@@ -144,6 +142,23 @@ final class SqlQuery implements SqlQueryInterface
 
         /** @psalm-suppress PossiblyNullArgument */
         return $fetch->fetchAll($pdoStatement, $this->injector);
+    }
+
+    /**
+     * Remove comments from SQL query for query type detection
+     *
+     * This strips both C-style (/* *\/) and line comments (--) to prevent
+     * misidentification of query type. The original query sent to the database
+     * remains unchanged to preserve performance hints and annotations.
+     */
+    private function removeCommentsForDetection(string $sql): string
+    {
+        // Remove C-style comments
+        $sql = (string) preg_replace(self::C_STYLE_COMMENT, '', $sql);
+        // Remove line comments (-- at start of line, optionally after whitespace)
+        $sql = (string) preg_replace(self::LINE_COMMENT, '', $sql);
+
+        return trim($sql);
     }
 
     /** @return non-empty-array<string> */

--- a/tests/SqlCommentTest.php
+++ b/tests/SqlCommentTest.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Ray\MediaQuery;
 
 use Aura\Sql\ExtendedPdo;
+use Pagerfanta\View\DefaultView;
 use PDO;
 use PHPUnit\Framework\TestCase;
 use Ray\AuraSqlModule\Pagerfanta\AuraSqlPager;
 use Ray\AuraSqlModule\Pagerfanta\AuraSqlPagerFactory;
 use Ray\Di\Injector;
 use Ray\InputQuery\ToArray;
-use Pagerfanta\View\DefaultView;
 
 use function file_get_contents;
 

--- a/tests/SqlCommentTest.php
+++ b/tests/SqlCommentTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+
+use Aura\Sql\ExtendedPdo;
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Ray\AuraSqlModule\Pagerfanta\AuraSqlPager;
+use Ray\AuraSqlModule\Pagerfanta\AuraSqlPagerFactory;
+use Ray\Di\Injector;
+use Ray\InputQuery\ToArray;
+use Pagerfanta\View\DefaultView;
+
+use function file_get_contents;
+
+class SqlCommentTest extends TestCase
+{
+    private SqlQuery $sqlQuery;
+
+    /** @var array<string, mixed> */
+    private array $insertData = ['id' => '1', 'title' => 'test'];
+
+    protected function setUp(): void
+    {
+        $sqlDir = __DIR__ . '/sql';
+        $pdo = new ExtendedPdo('sqlite::memory:', '', '', [PDO::ATTR_STRINGIFY_FETCHES => true]);
+        $pdo->query((string) file_get_contents($sqlDir . '/create_todo.sql'));
+        $pdo->perform((string) file_get_contents($sqlDir . '/todo_add.sql'), $this->insertData);
+
+        $this->sqlQuery = new SqlQuery(
+            $pdo,
+            __DIR__ . '/sql',
+            new MediaQueryLogger(),
+            new AuraSqlPagerFactory(new AuraSqlPager(new DefaultView(), [])),
+            new ParamConverter(new ToArray()),
+            new Injector(),
+            new PerformTemplatedSql('{{ sql }}'),
+        );
+    }
+
+    public function testInsertWithSelectInComment(): void
+    {
+        // Critical test: -- SELECT comment should not cause INSERT to be detected as SELECT
+        $data = ['id' => '2', 'title' => 'test2'];
+        $this->sqlQuery->exec('todo_insert_with_select_comment', $data);
+
+        // Verify the INSERT worked
+        $result = $this->sqlQuery->getRow('todo_item', ['id' => '2']);
+        $this->assertSame($data, $result);
+    }
+
+    public function testSelectWithLeadingDashComment(): void
+    {
+        $result = $this->sqlQuery->getRow('todo_select_with_leading_comment', ['id' => '1']);
+        $this->assertSame($this->insertData, $result);
+    }
+
+    public function testUpdateWithInsertComment(): void
+    {
+        $updatedTitle = 'updated';
+        $this->sqlQuery->exec('todo_update_with_insert_comment', ['id' => '1', 'title' => $updatedTitle]);
+
+        // Verify the UPDATE worked
+        $result = $this->sqlQuery->getRow('todo_item', ['id' => '1']);
+        $this->assertSame(['id' => '1', 'title' => $updatedTitle], $result);
+    }
+}

--- a/tests/SqlCommentTest.php
+++ b/tests/SqlCommentTest.php
@@ -66,4 +66,13 @@ class SqlCommentTest extends TestCase
         $result = $this->sqlQuery->getRow('todo_item', ['id' => '1']);
         $this->assertSame(['id' => '1', 'title' => $updatedTitle], $result);
     }
+
+    public function testDashesInStringLiteral(): void
+    {
+        // Test that -- inside string literals is not stripped
+        // This query should work correctly despite having -- in the WHERE clause
+        $result = $this->sqlQuery->getRow('todo_with_dashes_in_string', ['id' => '1']);
+        // Since 'test--value' won't match 'test', we expect null
+        $this->assertNull($result);
+    }
 }

--- a/tests/sql/create_promise.sql
+++ b/tests/sql/create_promise.sql
@@ -1,5 +1,6 @@
-CREATE TABLE IF NOT EXISTS todo
+CREATE TABLE IF NOT EXISTS promise
 (
-    id    INTEGER,
-    title TEXT
+    id    TEXT,
+    title TEXT,
+    time  TEXT
 )

--- a/tests/sql/create_todo.sql
+++ b/tests/sql/create_todo.sql
@@ -1,6 +1,5 @@
-CREATE TABLE IF NOT EXISTS promise
+CREATE TABLE IF NOT EXISTS todo
 (
     id    TEXT,
-    title TEXT,
-    time  TEXT
+    title TEXT
 )

--- a/tests/sql/todo_insert_with_select_comment.sql
+++ b/tests/sql/todo_insert_with_select_comment.sql
@@ -1,0 +1,3 @@
+-- SELECT for testing INSERT detection
+-- This comment should not affect query type detection
+INSERT INTO todo (id, title) VALUES (:id, :title);

--- a/tests/sql/todo_select_with_leading_comment.sql
+++ b/tests/sql/todo_select_with_leading_comment.sql
@@ -1,0 +1,3 @@
+-- Query to select todo by id
+-- Author: Test
+SELECT * FROM todo WHERE id = :id;

--- a/tests/sql/todo_update_with_insert_comment.sql
+++ b/tests/sql/todo_update_with_insert_comment.sql
@@ -1,0 +1,2 @@
+-- INSERT comment that should not trigger INSERT detection
+UPDATE todo SET title = :title WHERE id = :id;

--- a/tests/sql/todo_with_dashes_in_string.sql
+++ b/tests/sql/todo_with_dashes_in_string.sql
@@ -1,0 +1,1 @@
+SELECT * FROM todo WHERE title = 'test--value' AND id = :id;


### PR DESCRIPTION
Fixed an issue where line comments (--) in SQL files caused incorrect query type detection. For example, an INSERT statement with a comment like "-- SELECT for xxx" at the beginning would be incorrectly identified as a SELECT query.

Changes:
- Add LINE_COMMENT regex pattern to remove -- style comments
- Strip both /* */ and -- comments during query type detection only
- Preserve comments when sending queries to the database (important for MySQL performance hints and annotations)
- Add comprehensive tests for comment handling edge cases

Queries sent to the database remain unchanged (comments preserved), while query type detection (SELECT vs INSERT/UPDATE/DELETE) now correctly ignores comment content.

## Summary by Sourcery

Improve SQL query type detection by ignoring comments while preserving them for execution.

Bug Fixes:
- Fix misclassification of SQL query types when line comments contain misleading keywords like SELECT or INSERT.

Enhancements:
- Add handling for SQL line comments in query type detection alongside existing C-style comment stripping.

Tests:
- Add integration tests covering INSERT, SELECT, and UPDATE statements with leading line comments containing other query keywords.
- Adjust test SQL schema files to support new comment-handling test cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query-type detection so SQL comments (line-style and block) and comment-like text no longer cause misclassification of INSERT/SELECT/UPDATE.

* **Tests**
  * Added tests covering leading comments, comments containing SQL, dashes inside string literals, and related edge cases.
  * Updated test SQL fixtures and schemas to validate the corrected behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->