### PR TITLE
Clone Pager attribute in DbPager::__invoke to prevent mutation

### DIFF
--- a/src/DbPager.php
+++ b/src/DbPager.php
@@ -23,6 +23,8 @@ final class DbPager
     /** @param array<string, mixed> $values */
     public function __invoke(string $queryId, array $values, Pager $pager, string|null $entity): PagesInterface
     {
+        // Clone the Pager attribute to avoid mutating the caller's instance in dynamicPager().
+        $pager = clone $pager;
         if (is_string($pager->perPage)) {
             $values = $this->dynamicPager($pager, $values);
         }

--- a/tests/DbPagerTest.php
+++ b/tests/DbPagerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Ray\MediaQuery;
 
-use ArrayIterator;
 use PHPUnit\Framework\TestCase;
 use Ray\MediaQuery\Annotation\Pager;
 
@@ -12,86 +11,8 @@ final class DbPagerTest extends TestCase
 {
     public function testPagerInstanceIsNotMutatedAcrossCalls(): void
     {
-        $sqlQuery = new class implements SqlQueryInterface {
-            /** @var list<int> */
-            public array $perPageHistory = [];
-
-            public function getRow(string $sqlId, array $values = [], FetchInterface|null $fetch = null): array|object|null
-            {
-                return null;
-            }
-
-            public function getRowList(string $sqlId, array $values = [], FetchInterface|null $fetch = null): array
-            {
-                return [];
-            }
-
-            public function exec(string $sqlId, array $values = [], FetchInterface|null $fetch = null): void
-            {
-            }
-
-            public function getCount(string $sqlId, array $values): int
-            {
-                return 0;
-            }
-
-            public function getPages(string $sqlId, array $values, int $perPage, string $queryTemplate = '/{?page}', string|null $entity = null): PagesInterface
-            {
-                $this->perPageHistory[] = $perPage;
-
-                return new class implements PagesInterface {
-                    /** @var ArrayIterator<int, mixed> */
-                    private ArrayIterator $iter;
-
-                    public function __construct()
-                    {
-                        $this->iter = new ArrayIterator([]);
-                    }
-
-                    public function offsetExists(mixed $offset): bool
-                    {
-                        return $this->iter->offsetExists($offset);
-                    }
-
-                    public function offsetGet(mixed $offset): mixed
-                    {
-                        return $this->iter->offsetGet($offset);
-                    }
-
-                    public function offsetSet(mixed $offset, mixed $value): void
-                    {
-                        $this->iter->offsetSet($offset, $value);
-                    }
-
-                    public function offsetUnset(mixed $offset): void
-                    {
-                        $this->iter->offsetUnset($offset);
-                    }
-
-                    public function count(): int
-                    {
-                        return $this->iter->count();
-                    }
-                };
-            }
-        };
-
-        $logger = new class implements MediaQueryLoggerInterface {
-            public function start(): void
-            {
-            }
-
-            public function log(string $queryId, array $values): void
-            {
-            }
-
-            public function __toString(): string
-            {
-                return '';
-            }
-        };
-
-        $dbPager = new DbPager($logger, $sqlQuery);
+        $sqlQuery = new FakeSqlQuery();
+        $dbPager = new DbPager(new FakeMediaQueryLogger(), $sqlQuery);
 
         // The Pager attribute instance is shared across multiple calls,
         // mirroring how a cached annotation would be reused in production code.

--- a/tests/DbPagerTest.php
+++ b/tests/DbPagerTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+
+use ArrayIterator;
+use PHPUnit\Framework\TestCase;
+use Ray\MediaQuery\Annotation\Pager;
+
+final class DbPagerTest extends TestCase
+{
+    public function testPagerInstanceIsNotMutatedAcrossCalls(): void
+    {
+        $sqlQuery = new class implements SqlQueryInterface {
+            /** @var list<int> */
+            public array $perPageHistory = [];
+
+            public function getRow(string $sqlId, array $values = [], FetchInterface|null $fetch = null): array|object|null
+            {
+                return null;
+            }
+
+            public function getRowList(string $sqlId, array $values = [], FetchInterface|null $fetch = null): array
+            {
+                return [];
+            }
+
+            public function exec(string $sqlId, array $values = [], FetchInterface|null $fetch = null): void
+            {
+            }
+
+            public function getCount(string $sqlId, array $values): int
+            {
+                return 0;
+            }
+
+            public function getPages(string $sqlId, array $values, int $perPage, string $queryTemplate = '/{?page}', string|null $entity = null): PagesInterface
+            {
+                $this->perPageHistory[] = $perPage;
+
+                return new class implements PagesInterface {
+                    /** @var ArrayIterator<int, mixed> */
+                    private ArrayIterator $iter;
+
+                    public function __construct()
+                    {
+                        $this->iter = new ArrayIterator([]);
+                    }
+
+                    public function offsetExists(mixed $offset): bool
+                    {
+                        return $this->iter->offsetExists($offset);
+                    }
+
+                    public function offsetGet(mixed $offset): mixed
+                    {
+                        return $this->iter->offsetGet($offset);
+                    }
+
+                    public function offsetSet(mixed $offset, mixed $value): void
+                    {
+                        $this->iter->offsetSet($offset, $value);
+                    }
+
+                    public function offsetUnset(mixed $offset): void
+                    {
+                        $this->iter->offsetUnset($offset);
+                    }
+
+                    public function count(): int
+                    {
+                        return $this->iter->count();
+                    }
+                };
+            }
+        };
+
+        $logger = new class implements MediaQueryLoggerInterface {
+            public function start(): void
+            {
+            }
+
+            public function log(string $queryId, array $values): void
+            {
+            }
+
+            public function __toString(): string
+            {
+                return '';
+            }
+        };
+
+        $dbPager = new DbPager($logger, $sqlQuery);
+
+        // The Pager attribute instance is shared across multiple calls,
+        // mirroring how a cached annotation would be reused in production code.
+        $pager = new Pager(perPage: 'perPage', template: '/{?page}');
+
+        foreach ([2, 1, 3] as $perPage) {
+            ($dbPager)('todo_list', ['perPage' => $perPage], $pager, null);
+        }
+
+        $this->assertSame('perPage', $pager->perPage, 'Pager::$perPage must remain the original key string');
+        $this->assertSame([2, 1, 3], $sqlQuery->perPageHistory, 'Each call must forward its own perPage to SqlQuery::getPages()');
+    }
+}

--- a/tests/Fake/FakeEmptyPages.php
+++ b/tests/Fake/FakeEmptyPages.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+
+use ArrayIterator;
+
+final class FakeEmptyPages implements PagesInterface
+{
+    /** @var ArrayIterator<int, mixed> */
+    private ArrayIterator $iter;
+
+    public function __construct()
+    {
+        $this->iter = new ArrayIterator([]);
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return $this->iter->offsetExists($offset);
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->iter->offsetGet($offset);
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->iter->offsetSet($offset, $value);
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        $this->iter->offsetUnset($offset);
+    }
+
+    public function count(): int
+    {
+        return $this->iter->count();
+    }
+}

--- a/tests/Fake/FakeMediaQueryLogger.php
+++ b/tests/Fake/FakeMediaQueryLogger.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+
+final class FakeMediaQueryLogger implements MediaQueryLoggerInterface
+{
+    public function start(): void
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param array<string, mixed> $values
+     */
+    public function log(string $queryId, array $values): void
+    {
+    }
+
+    public function __toString(): string
+    {
+        return '';
+    }
+}

--- a/tests/Fake/FakeSqlQuery.php
+++ b/tests/Fake/FakeSqlQuery.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+
+final class FakeSqlQuery implements SqlQueryInterface
+{
+    /** @var list<int> */
+    public array $perPageHistory = [];
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param array<string, mixed> $values
+     */
+    public function getRow(string $sqlId, array $values = [], FetchInterface|null $fetch = null): array|object|null
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param array<string, mixed> $values
+     */
+    public function getRowList(string $sqlId, array $values = [], FetchInterface|null $fetch = null): array
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param array<string, mixed> $values
+     */
+    public function exec(string $sqlId, array $values = [], FetchInterface|null $fetch = null): void
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param array<string, mixed> $values
+     */
+    public function getCount(string $sqlId, array $values): int
+    {
+        return 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param array<string, mixed> $values
+     */
+    public function getPages(string $sqlId, array $values, int $perPage, string $queryTemplate = '/{?page}', string|null $entity = null): PagesInterface
+    {
+        $this->perPageHistory[] = $perPage;
+
+        return new FakeEmptyPages();
+    }
+}


### PR DESCRIPTION
## Summary

- Stop `DbPager::__invoke()` from mutating the `#[Pager]` attribute instance it receives by cloning it at the top of the method.
- Add a regression test that constructs `DbPager` directly with minimal fakes, reuses the same `Pager` instance across three calls, and asserts both that `$pager->perPage` stays the original key string and that each call forwards its own `perPage` to `SqlQueryInterface::getPages()`.

Fixes #80

## Commits

1. `Add failing test for DbPager Pager attribute mutation` — red test that fails on current `1.x` (first call mutates `$pager->perPage` from `'perPage'` to `int`, assertion fails immediately).
2. `Clone Pager attribute in DbPager::__invoke to prevent mutation` — one-line fix (`$pager = clone $pager;`) that turns the red test green.

## Impact on typical AOP usage

On current Ray.Aop (2.19.0) `ReflectionMethod::getAnnotation()` returns a fresh `Pager` on every call, so AOP-driven production traffic has not observed this leak. The fix is defensive and restores the API contract for any caller that holds on to a `Pager` instance (custom interceptors, unit tests, third-party code, or any future Ray.Aop change that caches reflection results).

## Test plan

- [x] `composer cs-fix` — no violations
- [x] `composer sa` — Psalm + PHPStan clean
- [x] `composer tests` — 88 tests, 130 assertions, all pass
- [x] New `DbPagerTest::testPagerInstanceIsNotMutatedAcrossCalls` fails on the red commit and passes on the green commit

## Summary by Sourcery

Prevent DbPager from mutating the Pager attribute instance it receives and add a regression test to ensure pager state remains consistent across multiple invocations.

Bug Fixes:
- Ensure DbPager clones the Pager attribute to avoid mutating the caller-provided instance when resolving dynamic pagination settings.

Tests:
- Add a regression test verifying that a shared Pager instance is not mutated across multiple DbPager invocations and that each call forwards its own perPage value to SqlQueryInterface::getPages().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where DbPager would mutate the original Pager instance when invoked multiple times, ensuring the caller's Pager object remains unchanged.

* **Tests**
  * Added regression test to verify Pager instances are not mutated across consecutive calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->