### PR TITLE
Add 1.0.4 release entry to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] - 2026-04-14
+
+### Fixed
+- Fix `DbPager` mutating the `#[Pager]` attribute instance it receives. `DbPager::__invoke()` now clones the Pager at entry so `dynamicPager()` no longer writes back to the caller's instance ([#80](https://github.com/ray-di/Ray.MediaQuery/issues/80), [#81](https://github.com/ray-di/Ray.MediaQuery/pull/81))
+
 ## [1.0.3] - 2025-01-25
 
 ### Changed


### PR DESCRIPTION
## Summary

- Add the `1.0.4` entry to `CHANGELOG.md` covering the `DbPager` Pager mutation fix merged in #81 / closes #80.

## Test plan

- [x] CHANGELOG format matches the existing `1.0.3` entry

## Summary by Sourcery

Documentation:
- Add a 1.0.4 changelog entry describing the DbPager pager mutation bug fix.