### PR TITLE
DML result types via PostQueryInterface (AffectedRows / InsertedRow)

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,8 @@ $result->isAffected();  // bool — true when count > 0
 
 `lastInsertId` is normalised to `null` for non-`INSERT` statements and for inserts that do not produce an auto-increment value. Existing `void` return types keep working unchanged.
 
+When a SQL file contains multiple statements (separated by `;`), `AffectedRows` reflects the **last executed statement only**.
+
 **Constructor Property Promotion (Recommended):**
 
 Use constructor property promotion for type-safe, immutable entities:

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ final class RowCountWithQuery implements PostQueryInterface
         public readonly string $queryString,
     ) {}
 
-    public static function postQuery(PostQueryContext $context): static
+    public static function fromContext(PostQueryContext $context): static
     {
         return new static($context->statement->rowCount(), $context->statement->queryString);
     }

--- a/README.md
+++ b/README.md
@@ -249,6 +249,30 @@ interface UserRepository
 }
 ```
 
+**DML Result (`AffectedRows`):**
+
+Declare an `AffectedRows` return type on `INSERT` / `UPDATE` / `DELETE` methods to receive the row count and (for `INSERT`) the last insert id:
+
+```php
+use Ray\MediaQuery\Result\AffectedRows;
+
+interface TodoRepository
+{
+    #[DbQuery('todo_add')]
+    public function add(string $title): AffectedRows;
+
+    #[DbQuery('todo_delete')]
+    public function delete(string $id): AffectedRows;
+}
+
+$result = $todoRepo->add('Write docs');
+$result->count;         // int — number of affected rows
+$result->lastInsertId;  // ?string — auto-increment id after INSERT, null otherwise
+$result->isAffected();  // bool — true when count > 0
+```
+
+`lastInsertId` is normalised to `null` for non-`INSERT` statements and for inserts that do not produce an auto-increment value. Existing `void` return types keep working unchanged.
+
 **Constructor Property Promotion (Recommended):**
 
 Use constructor property promotion for type-safe, immutable entities:
@@ -503,6 +527,8 @@ class CustomRepository
 - `getRow($queryId, $params)` - Single row
 - `getRowList($queryId, $params)` - Multiple rows
 - `exec($queryId, $params)` - Execute without result
+- `getAffectedRows($queryId, $params)` - Execute DML and return `AffectedRows` (count + lastInsertId)
+- `getCount($queryId, $params)` - Total row count (for pagination)
 - `getStatement()` - Get PDO statement
 - `getPages()` - Get paginated results
 

--- a/README.md
+++ b/README.md
@@ -249,31 +249,67 @@ interface UserRepository
 }
 ```
 
-**DML Result (`AffectedRows`):**
+**DML Result types — `AffectedRows` / `InsertedRow`:**
 
-Declare an `AffectedRows` return type on `INSERT` / `UPDATE` / `DELETE` methods to receive the row count and (for `INSERT`) the last insert id:
+Declare a result type that implements `PostQueryInterface` to receive post-execution information. The framework ships two:
+
+- `AffectedRows` — row count for `UPDATE` / `DELETE`.
+- `InsertedRow` — the resolved parameter values plus the auto-increment id for `INSERT`.
 
 ```php
 use Ray\MediaQuery\Result\AffectedRows;
+use Ray\MediaQuery\Result\InsertedRow;
 
 interface TodoRepository
 {
     #[DbQuery('todo_add')]
-    public function add(string $title): AffectedRows;
+    public function add(string $title): InsertedRow;
+
+    #[DbQuery('todo_update')]
+    public function update(string $id, string $title): AffectedRows;
 
     #[DbQuery('todo_delete')]
     public function delete(string $id): AffectedRows;
 }
 
-$result = $todoRepo->add('Write docs');
-$result->count;         // int — number of affected rows
-$result->lastInsertId;  // ?string — auto-increment id after INSERT, null otherwise
-$result->isAffected();  // bool — true when count > 0
+$inserted = $todoRepo->add('Write docs');
+$inserted->values;  // array<string, mixed> — parameters as bound to the driver (UUIDs, timestamps, DateTime→string, ToScalar reductions all resolved)
+$inserted->id;      // ?string — auto-increment id, null if the driver reports none
+
+$deleted = $todoRepo->delete('1');
+$deleted->count;       // int — rows deleted
+$deleted->isAffected();  // bool — true when count > 0
 ```
 
-`lastInsertId` is normalised to `null` for non-`INSERT` statements and for inserts that do not produce an auto-increment value. Existing `void` return types keep working unchanged.
+`InsertedRow::$values` is the result of Ray.MediaQuery's parameter resolution — injected defaults (UUIDs, timestamps), `DateTime` converted to SQL strings, and `ToScalarInterface` value objects reduced to scalars. Those are the values that actually went to the database and are not otherwise observable by the caller.
 
-When a SQL file contains multiple statements (separated by `;`), `AffectedRows` reflects the **last executed statement only**.
+The return type **is** the intent declaration — the framework does not sniff the SQL. Pick `InsertedRow` when you need the id or the resolved values, `AffectedRows` otherwise. Existing `void` return types keep working unchanged.
+
+When a SQL file contains multiple statements (separated by `;`), the result reflects the **last executed statement only**.
+
+**Custom result types:**
+
+Any class implementing `Ray\MediaQuery\Result\PostQueryInterface` can be declared as a return type. The interface defines a single static factory that builds the result from a `PostQueryContext` carrying the executed statement, the connection, and the resolved parameter values:
+
+```php
+use Ray\MediaQuery\Result\PostQueryContext;
+use Ray\MediaQuery\Result\PostQueryInterface;
+
+final class RowCountWithQuery implements PostQueryInterface
+{
+    public function __construct(
+        public readonly int $count,
+        public readonly string $queryString,
+    ) {}
+
+    public static function postQuery(PostQueryContext $context): static
+    {
+        return new static($context->statement->rowCount(), $context->statement->queryString);
+    }
+}
+```
+
+Declare it on any `#[DbQuery]` method and the interceptor dispatches to the class's own factory.
 
 **Constructor Property Promotion (Recommended):**
 
@@ -529,7 +565,7 @@ class CustomRepository
 - `getRow($queryId, $params)` - Single row
 - `getRowList($queryId, $params)` - Multiple rows
 - `exec($queryId, $params)` - Execute without result
-- `execAffected($queryId, $params)` - Execute DML and return `AffectedRows` (count + lastInsertId)
+- `execPostQuery($queryId, $params, $postQueryClass)` - Execute DML and build a typed result via a `PostQueryInterface` class (e.g. `AffectedRows`, `InsertedRow`, or a custom class)
 - `getCount($queryId, $params)` - Total row count (for pagination)
 - `getStatement()` - Get PDO statement
 - `getPages()` - Get paginated results

--- a/README.md
+++ b/README.md
@@ -529,7 +529,7 @@ class CustomRepository
 - `getRow($queryId, $params)` - Single row
 - `getRowList($queryId, $params)` - Multiple rows
 - `exec($queryId, $params)` - Execute without result
-- `getAffectedRows($queryId, $params)` - Execute DML and return `AffectedRows` (count + lastInsertId)
+- `execAffected($queryId, $params)` - Execute DML and return `AffectedRows` (count + lastInsertId)
 - `getCount($queryId, $params)` - Total row count (for pagination)
 - `getStatement()` - Get PDO statement
 - `getPages()` - Get paginated results

--- a/src/DbQueryInterceptor.php
+++ b/src/DbQueryInterceptor.php
@@ -11,11 +11,13 @@ use Ray\Di\Di\Set;
 use Ray\Di\ProviderInterface;
 use Ray\MediaQuery\Annotation\DbQuery;
 use Ray\MediaQuery\Annotation\Pager;
-use Ray\MediaQuery\Result\AffectedRows;
+use Ray\MediaQuery\Result\PostQueryInterface;
 use ReflectionNamedType;
 use ReflectionUnionType;
 
 use function assert;
+use function class_exists;
+use function is_subclass_of;
 
 final class DbQueryInterceptor implements MethodInterceptor
 {
@@ -48,8 +50,11 @@ final class DbQueryInterceptor implements MethodInterceptor
 
         $returnType = $invocation->getMethod()->getReturnType();
         assert($returnType === null || $returnType instanceof ReflectionNamedType || $returnType instanceof ReflectionUnionType);
-        if ($returnType instanceof ReflectionNamedType && $returnType->getName() === AffectedRows::class) {
-            return $this->sqlQuery->execAffected($dbQuery->id, $values);
+        if ($returnType instanceof ReflectionNamedType) {
+            $typeName = $returnType->getName();
+            if (class_exists($typeName) && is_subclass_of($typeName, PostQueryInterface::class)) {
+                return $this->sqlQuery->execPostQuery($dbQuery->id, $values, $typeName);
+            }
         }
 
         $fetch = $this->factory->factory($dbQuery, $entity, $returnType);

--- a/src/DbQueryInterceptor.php
+++ b/src/DbQueryInterceptor.php
@@ -11,6 +11,7 @@ use Ray\Di\Di\Set;
 use Ray\Di\ProviderInterface;
 use Ray\MediaQuery\Annotation\DbQuery;
 use Ray\MediaQuery\Annotation\Pager;
+use Ray\MediaQuery\Result\AffectedRows;
 use ReflectionNamedType;
 use ReflectionUnionType;
 
@@ -47,6 +48,10 @@ final class DbQueryInterceptor implements MethodInterceptor
 
         $returnType = $invocation->getMethod()->getReturnType();
         assert($returnType === null || $returnType instanceof ReflectionNamedType || $returnType instanceof ReflectionUnionType);
+        if ($returnType instanceof ReflectionNamedType && $returnType->getName() === AffectedRows::class) {
+            return $this->sqlQuery->getAffectedRows($dbQuery->id, $values);
+        }
+
         $fetch = $this->factory->factory($dbQuery, $entity, $returnType);
         $isRow = $dbQuery->type === 'row' || $returnType instanceof ReflectionUnionType || ($returnType instanceof ReflectionNamedType && $returnType->getName() !== 'array');
 

--- a/src/DbQueryInterceptor.php
+++ b/src/DbQueryInterceptor.php
@@ -49,7 +49,7 @@ final class DbQueryInterceptor implements MethodInterceptor
         $returnType = $invocation->getMethod()->getReturnType();
         assert($returnType === null || $returnType instanceof ReflectionNamedType || $returnType instanceof ReflectionUnionType);
         if ($returnType instanceof ReflectionNamedType && $returnType->getName() === AffectedRows::class) {
-            return $this->sqlQuery->getAffectedRows($dbQuery->id, $values);
+            return $this->sqlQuery->execAffected($dbQuery->id, $values);
         }
 
         $fetch = $this->factory->factory($dbQuery, $entity, $returnType);

--- a/src/Result/AffectedRows.php
+++ b/src/Result/AffectedRows.php
@@ -4,23 +4,28 @@ declare(strict_types=1);
 
 namespace Ray\MediaQuery\Result;
 
+use Override;
+
 /**
- * Result of a DML execution returned by SqlQueryInterface::execAffected()
- * and DbQuery methods that declare an AffectedRows return type.
+ * Row-count result for UPDATE / DELETE statements.
+ *
+ * Declare `AffectedRows` as the return type of a `#[DbQuery]` method to receive
+ * the number of rows affected by the statement. Use {@see InsertedRow} instead
+ * when the caller needs the auto-increment id and the resolved values after an
+ * INSERT.
  */
-final class AffectedRows
+final class AffectedRows implements PostQueryInterface
 {
-    /**
-     * @param int         $count        Number of rows affected by the last executed statement.
-     * @param string|null $lastInsertId Auto-increment id assigned by an INSERT. Null for
-     *                                  non-INSERT statements, and also when the driver
-     *                                  reports no id (e.g. tables without AUTO_INCREMENT,
-     *                                  or values '0' / '' which are normalised to null).
-     */
+    /** @param int $count Number of rows affected by the last executed statement. */
     public function __construct(
         public readonly int $count,
-        public readonly string|null $lastInsertId = null,
     ) {
+    }
+
+    #[Override]
+    public static function postQuery(PostQueryContext $context): static
+    {
+        return new static($context->statement->rowCount());
     }
 
     public function isAffected(): bool

--- a/src/Result/AffectedRows.php
+++ b/src/Result/AffectedRows.php
@@ -23,7 +23,7 @@ final class AffectedRows implements PostQueryInterface
     }
 
     #[Override]
-    public static function postQuery(PostQueryContext $context): static
+    public static function fromContext(PostQueryContext $context): static
     {
         return new static($context->statement->rowCount());
     }

--- a/src/Result/AffectedRows.php
+++ b/src/Result/AffectedRows.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery\Result;
+
+final class AffectedRows
+{
+    public function __construct(
+        public readonly int $count,
+        public readonly string|null $lastInsertId = null,
+    ) {
+    }
+
+    public function isAffected(): bool
+    {
+        return $this->count > 0;
+    }
+}

--- a/src/Result/AffectedRows.php
+++ b/src/Result/AffectedRows.php
@@ -4,8 +4,19 @@ declare(strict_types=1);
 
 namespace Ray\MediaQuery\Result;
 
+/**
+ * Result of a DML execution returned by SqlQueryInterface::execAffected()
+ * and DbQuery methods that declare an AffectedRows return type.
+ */
 final class AffectedRows
 {
+    /**
+     * @param int         $count        Number of rows affected by the last executed statement.
+     * @param string|null $lastInsertId Auto-increment id assigned by an INSERT. Null for
+     *                                  non-INSERT statements, and also when the driver
+     *                                  reports no id (e.g. tables without AUTO_INCREMENT,
+     *                                  or values '0' / '' which are normalised to null).
+     */
     public function __construct(
         public readonly int $count,
         public readonly string|null $lastInsertId = null,

--- a/src/Result/InsertedRow.php
+++ b/src/Result/InsertedRow.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery\Result;
+
+use Override;
+
+/**
+ * Data inserted by an INSERT statement — the resolved parameter values bound to
+ * the driver, plus the auto-increment id the driver reports back.
+ *
+ * Declare `InsertedRow` as the return type of a `#[DbQuery]` method to recover
+ * values that the framework injected on the caller's behalf (UUIDs for null
+ * defaults, timestamps, `DateTime` → SQL-string conversion, `ToScalarInterface`
+ * value objects reduced to scalars). Those resolved values are what actually
+ * went to the database and are not otherwise observable by the caller.
+ *
+ * For bulk `INSERT ... SELECT` or `ON DUPLICATE KEY UPDATE` where only the row
+ * count matters, use {@see AffectedRows} instead.
+ */
+final class InsertedRow implements PostQueryInterface
+{
+    /**
+     * @param array<string, mixed> $values Parameter values resolved by ParamConverter /
+     *                                     ParamInjector and bound to the driver.
+     * @param string|null          $id     Auto-increment id assigned by the INSERT, or null
+     *                                     when the driver reports none (tables without
+     *                                     AUTO_INCREMENT, or values `false` / `''` / `'0'`,
+     *                                     all normalised to null).
+     */
+    public function __construct(
+        public readonly array $values,
+        public readonly string|null $id,
+    ) {
+    }
+
+    #[Override]
+    public static function postQuery(PostQueryContext $context): static
+    {
+        $id = $context->pdo->lastInsertId();
+        $lastInsertId = $id === false || $id === '' || $id === '0' ? null : $id;
+
+        return new static($context->values, $lastInsertId);
+    }
+}

--- a/src/Result/InsertedRow.php
+++ b/src/Result/InsertedRow.php
@@ -36,7 +36,7 @@ final class InsertedRow implements PostQueryInterface
     }
 
     #[Override]
-    public static function postQuery(PostQueryContext $context): static
+    public static function fromContext(PostQueryContext $context): static
     {
         $id = $context->pdo->lastInsertId();
         $lastInsertId = $id === false || $id === '' || $id === '0' ? null : $id;

--- a/src/Result/PostQueryContext.php
+++ b/src/Result/PostQueryContext.php
@@ -8,7 +8,7 @@ use Aura\Sql\ExtendedPdoInterface;
 use PDOStatement;
 
 /**
- * Context passed to {@see PostQueryInterface::postQuery()} after DML execution.
+ * Context passed to {@see PostQueryInterface::fromContext()} after DML execution.
  *
  * Carries the executed statement, the connection, and the parameter values as
  * resolved by `ParamConverter` / `ParamInjector` — i.e. with injected defaults

--- a/src/Result/PostQueryContext.php
+++ b/src/Result/PostQueryContext.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery\Result;
+
+use Aura\Sql\ExtendedPdoInterface;
+use PDOStatement;
+
+/**
+ * Context passed to {@see PostQueryInterface::postQuery()} after DML execution.
+ *
+ * Carries the executed statement, the connection, and the parameter values as
+ * resolved by `ParamConverter` / `ParamInjector` — i.e. with injected defaults
+ * (UUIDs, timestamps), `DateTime` converted to SQL strings, and `ToScalarInterface`
+ * value objects reduced to scalars. These resolved values are what actually went
+ * to the driver, and they are not otherwise observable by the caller.
+ */
+final class PostQueryContext
+{
+    /** @param array<string, mixed> $values */
+    public function __construct(
+        public readonly PDOStatement $statement,
+        public readonly ExtendedPdoInterface $pdo,
+        public readonly array $values,
+    ) {
+    }
+}

--- a/src/Result/PostQueryInterface.php
+++ b/src/Result/PostQueryInterface.php
@@ -9,12 +9,12 @@ namespace Ray\MediaQuery\Result;
  *
  * Any class implementing this interface can be declared as the return type of
  * a `#[DbQuery]` method. The DbQueryInterceptor detects the interface via
- * `is_subclass_of` and calls the static {@see self::postQuery()} factory with
+ * `is_subclass_of` and calls the static {@see self::fromContext()} factory with
  * a {@see PostQueryContext} holding the executed statement, its connection,
  * and the resolved parameter values. Each result class owns the logic that
  * turns that context into its own shape.
  */
 interface PostQueryInterface
 {
-    public static function postQuery(PostQueryContext $context): static;
+    public static function fromContext(PostQueryContext $context): static;
 }

--- a/src/Result/PostQueryInterface.php
+++ b/src/Result/PostQueryInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery\Result;
+
+/**
+ * Return-type contract for DML results built from post-execution PDO state.
+ *
+ * Any class implementing this interface can be declared as the return type of
+ * a `#[DbQuery]` method. The DbQueryInterceptor detects the interface via
+ * `is_subclass_of` and calls the static {@see self::postQuery()} factory with
+ * a {@see PostQueryContext} holding the executed statement, its connection,
+ * and the resolved parameter values. Each result class owns the logic that
+ * turns that context into its own shape.
+ */
+interface PostQueryInterface
+{
+    public static function postQuery(PostQueryContext $context): static;
+}

--- a/src/SqlQuery.php
+++ b/src/SqlQuery.php
@@ -15,6 +15,7 @@ use Ray\Di\InjectorInterface;
 use Ray\MediaQuery\Annotation\Qualifier\SqlDir;
 use Ray\MediaQuery\Exception\InvalidSqlException;
 use Ray\MediaQuery\Exception\PdoPerformException;
+use Ray\MediaQuery\Result\AffectedRows;
 
 use function array_pop;
 use function assert;
@@ -94,6 +95,28 @@ final class SqlQuery implements SqlQueryInterface
         $list =  $this->perform($sqlId, $values, $fetch);
 
         return $list;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @psalm-taint-escape sql
+     */
+    #[Override]
+    public function getAffectedRows(string $sqlId, array $values = []): AffectedRows
+    {
+        $this->perform($sqlId, $values, null);
+        assert($this->pdoStatement instanceof PDOStatement);
+        $count = $this->pdoStatement->rowCount();
+
+        $query = $this->removeCommentsForDetection($this->pdoStatement->queryString);
+        $lastInsertId = null;
+        if (stripos($query, 'insert') === 0) {
+            $id = $this->pdo->lastInsertId();
+            $lastInsertId = $id === false || $id === '' || $id === '0' ? null : $id;
+        }
+
+        return new AffectedRows($count, $lastInsertId);
     }
 
     /**

--- a/src/SqlQuery.php
+++ b/src/SqlQuery.php
@@ -15,7 +15,8 @@ use Ray\Di\InjectorInterface;
 use Ray\MediaQuery\Annotation\Qualifier\SqlDir;
 use Ray\MediaQuery\Exception\InvalidSqlException;
 use Ray\MediaQuery\Exception\PdoPerformException;
-use Ray\MediaQuery\Result\AffectedRows;
+use Ray\MediaQuery\Result\PostQueryContext;
+use Ray\MediaQuery\Result\PostQueryInterface;
 
 use function array_pop;
 use function assert;
@@ -40,6 +41,9 @@ final class SqlQuery implements SqlQueryInterface
     private const LINE_COMMENT = '/^\s*--[^\r\n]*/m';
 
     private PDOStatement|null $pdoStatement = null;
+
+    /** @var array<string, mixed> */
+    private array $lastValues = [];
 
     public function __construct(
         private ExtendedPdoInterface $pdo,
@@ -103,20 +107,14 @@ final class SqlQuery implements SqlQueryInterface
      * @psalm-taint-escape sql
      */
     #[Override]
-    public function execAffected(string $sqlId, array $values = []): AffectedRows
+    public function execPostQuery(string $sqlId, array $values, string $postQueryClass): PostQueryInterface
     {
         $this->perform($sqlId, $values, null);
         assert($this->pdoStatement instanceof PDOStatement);
-        $count = $this->pdoStatement->rowCount();
 
-        $query = $this->removeCommentsForDetection($this->pdoStatement->queryString);
-        $lastInsertId = null;
-        if (stripos($query, 'insert') === 0) {
-            $id = $this->pdo->lastInsertId();
-            $lastInsertId = $id === false || $id === '' || $id === '0' ? null : $id;
-        }
+        $context = new PostQueryContext($this->pdoStatement, $this->pdo, $this->lastValues);
 
-        return new AffectedRows($count, $lastInsertId);
+        return $postQueryClass::postQuery($context);
     }
 
     /**
@@ -154,6 +152,8 @@ final class SqlQuery implements SqlQueryInterface
         }
 
         $this->pdoStatement = $pdoStatement;
+        /** @var array<string, mixed> $values */
+        $this->lastValues = $values;
         $lastQuery = $pdoStatement->queryString;
         $queryForDetection = $this->removeCommentsForDetection($lastQuery);
         $isSelect = stripos($queryForDetection, 'select') === 0 || stripos($queryForDetection, 'with') === 0;

--- a/src/SqlQuery.php
+++ b/src/SqlQuery.php
@@ -114,7 +114,7 @@ final class SqlQuery implements SqlQueryInterface
 
         $context = new PostQueryContext($this->pdoStatement, $this->pdo, $this->lastValues);
 
-        return $postQueryClass::postQuery($context);
+        return $postQueryClass::fromContext($context);
     }
 
     /**

--- a/src/SqlQuery.php
+++ b/src/SqlQuery.php
@@ -36,7 +36,7 @@ use const JSON_THROW_ON_ERROR;
 
 final class SqlQuery implements SqlQueryInterface
 {
-    private const C_STYLE_COMMENT = '/\/\*(.*?)\*\//u';
+    private const C_STYLE_COMMENT = '/\/\*.*?\*\//su';
     private const LINE_COMMENT = '/^\s*--[^\r\n]*/m';
 
     private PDOStatement|null $pdoStatement = null;

--- a/src/SqlQuery.php
+++ b/src/SqlQuery.php
@@ -103,7 +103,7 @@ final class SqlQuery implements SqlQueryInterface
      * @psalm-taint-escape sql
      */
     #[Override]
-    public function getAffectedRows(string $sqlId, array $values = []): AffectedRows
+    public function execAffected(string $sqlId, array $values = []): AffectedRows
     {
         $this->perform($sqlId, $values, null);
         assert($this->pdoStatement instanceof PDOStatement);

--- a/src/SqlQueryInterface.php
+++ b/src/SqlQueryInterface.php
@@ -9,6 +9,8 @@ use Ray\MediaQuery\Result\AffectedRows;
 interface SqlQueryInterface
 {
     /**
+     * Execute a SELECT and return the first row, or null when no rows match.
+     *
      * @param array<string, mixed> $values
      *
      * @return array<mixed>|object|null
@@ -18,6 +20,8 @@ interface SqlQueryInterface
     public function getRow(string $sqlId, array $values = [], FetchInterface|null $fetch = null): array|object|null;
 
     /**
+     * Execute a SELECT and return all rows.
+     *
      * @param array<string, mixed> $values
      *
      * @return array<array<mixed>>
@@ -27,6 +31,9 @@ interface SqlQueryInterface
     public function getRowList(string $sqlId, array $values = [], FetchInterface|null $fetch = null): array;
 
     /**
+     * Execute a statement without reading a result. Use {@see self::getAffectedRows()}
+     * when the DML row count or last insert id is needed.
+     *
      * @param array<string, mixed> $values
      *
      * @psalm-taint-escape sql
@@ -34,6 +41,10 @@ interface SqlQueryInterface
     public function exec(string $sqlId, array $values = [], FetchInterface|null $fetch = null): void;
 
     /**
+     * Execute a DML statement and return the affected row count and, for INSERT,
+     * the last insert id. When the SQL file contains multiple statements, the
+     * result reflects the last executed statement only.
+     *
      * @param array<string, mixed> $values
      *
      * @psalm-taint-escape sql
@@ -41,6 +52,8 @@ interface SqlQueryInterface
     public function getAffectedRows(string $sqlId, array $values = []): AffectedRows;
 
     /**
+     * Return the total row count for a SELECT. Used as the pagination denominator.
+     *
      * @param array<string, mixed> $values
      *
      * @psalm-taint-escape sql
@@ -48,6 +61,8 @@ interface SqlQueryInterface
     public function getCount(string $sqlId, array $values): int;
 
     /**
+     * Execute a SELECT through the paginator and return a lazy Pages wrapper.
+     *
      * @param array<string, mixed> $values
      * @param ?class-string        $entity
      *

--- a/src/SqlQueryInterface.php
+++ b/src/SqlQueryInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Ray\MediaQuery;
 
-use Ray\MediaQuery\Result\AffectedRows;
+use Ray\MediaQuery\Result\PostQueryInterface;
 
 /**
  * SQL query executor.
@@ -16,8 +16,9 @@ use Ray\MediaQuery\Result\AffectedRows;
  *              derivation of it ({@see self::getRow()}, {@see self::getRowList()},
  *              {@see self::getCount()}, {@see self::getPages()}).
  *  - `exec*` — DML queries (INSERT / UPDATE / DELETE); execute and either
- *              return nothing ({@see self::exec()}) or return the affected
- *              row count and last insert id ({@see self::execAffected()}).
+ *              return nothing ({@see self::exec()}) or return a typed result
+ *              built from the post-execution PDO state
+ *              ({@see self::execPostQuery()}).
  */
 interface SqlQueryInterface
 {
@@ -44,8 +45,8 @@ interface SqlQueryInterface
     public function getRowList(string $sqlId, array $values = [], FetchInterface|null $fetch = null): array;
 
     /**
-     * Execute a DML statement without reading a result. Use {@see self::execAffected()}
-     * when the affected row count or last insert id is needed.
+     * Execute a DML statement without reading a result. Use {@see self::execPostQuery()}
+     * when a typed result (row count, last insert id, etc.) is needed.
      *
      * @param array<string, mixed> $values
      *
@@ -54,15 +55,23 @@ interface SqlQueryInterface
     public function exec(string $sqlId, array $values = [], FetchInterface|null $fetch = null): void;
 
     /**
-     * Execute a DML statement and return the affected row count and, for INSERT,
-     * the last insert id. When the SQL file contains multiple statements, the
-     * result reflects the last executed statement only.
+     * Execute a DML statement and build a result through the given PostQuery class.
+     *
+     * The framework calls `{$postQueryClass}::postQuery($statement, $pdo)` after
+     * executing the SQL. Each result class owns its own construction logic, so
+     * the caller's return-type declaration is what selects behaviour (count only,
+     * count + last insert id, etc.). When the SQL file contains multiple
+     * statements, the result reflects the last executed statement only.
      *
      * @param array<string, mixed> $values
+     * @param class-string<T>      $postQueryClass
      *
+     * @return T
+     *
+     * @template T of PostQueryInterface
      * @psalm-taint-escape sql
      */
-    public function execAffected(string $sqlId, array $values = []): AffectedRows;
+    public function execPostQuery(string $sqlId, array $values, string $postQueryClass): PostQueryInterface;
 
     /**
      * Return the total row count for a SELECT. Used as the pagination denominator.

--- a/src/SqlQueryInterface.php
+++ b/src/SqlQueryInterface.php
@@ -57,7 +57,7 @@ interface SqlQueryInterface
     /**
      * Execute a DML statement and build a result through the given PostQuery class.
      *
-     * The framework calls `{$postQueryClass}::postQuery($statement, $pdo)` after
+     * The framework calls `{$postQueryClass}::fromContext($context)` after
      * executing the SQL. Each result class owns its own construction logic, so
      * the caller's return-type declaration is what selects behaviour (count only,
      * count + last insert id, etc.). When the SQL file contains multiple

--- a/src/SqlQueryInterface.php
+++ b/src/SqlQueryInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Ray\MediaQuery;
 
+use Ray\MediaQuery\Result\AffectedRows;
+
 interface SqlQueryInterface
 {
     /**
@@ -30,6 +32,13 @@ interface SqlQueryInterface
      * @psalm-taint-escape sql
      */
     public function exec(string $sqlId, array $values = [], FetchInterface|null $fetch = null): void;
+
+    /**
+     * @param array<string, mixed> $values
+     *
+     * @psalm-taint-escape sql
+     */
+    public function getAffectedRows(string $sqlId, array $values = []): AffectedRows;
 
     /**
      * @param array<string, mixed> $values

--- a/src/SqlQueryInterface.php
+++ b/src/SqlQueryInterface.php
@@ -6,6 +6,19 @@ namespace Ray\MediaQuery;
 
 use Ray\MediaQuery\Result\AffectedRows;
 
+/**
+ * SQL query executor.
+ *
+ * Methods in this interface execute the SQL identified by $sqlId every time
+ * they are called — the prefix signals the query kind, not a pure accessor:
+ *
+ *  - `get*`  — SELECT queries; execute and return the result set or a
+ *              derivation of it ({@see self::getRow()}, {@see self::getRowList()},
+ *              {@see self::getCount()}, {@see self::getPages()}).
+ *  - `exec*` — DML queries (INSERT / UPDATE / DELETE); execute and either
+ *              return nothing ({@see self::exec()}) or return the affected
+ *              row count and last insert id ({@see self::execAffected()}).
+ */
 interface SqlQueryInterface
 {
     /**
@@ -31,8 +44,8 @@ interface SqlQueryInterface
     public function getRowList(string $sqlId, array $values = [], FetchInterface|null $fetch = null): array;
 
     /**
-     * Execute a statement without reading a result. Use {@see self::getAffectedRows()}
-     * when the DML row count or last insert id is needed.
+     * Execute a DML statement without reading a result. Use {@see self::execAffected()}
+     * when the affected row count or last insert id is needed.
      *
      * @param array<string, mixed> $values
      *
@@ -49,7 +62,7 @@ interface SqlQueryInterface
      *
      * @psalm-taint-escape sql
      */
-    public function getAffectedRows(string $sqlId, array $values = []): AffectedRows;
+    public function execAffected(string $sqlId, array $values = []): AffectedRows;
 
     /**
      * Return the total row count for a SELECT. Used as the pagination denominator.

--- a/tests/DbQueryAffectedRowsTest.php
+++ b/tests/DbQueryAffectedRowsTest.php
@@ -11,6 +11,7 @@ use Ray\AuraSqlModule\AuraSqlModule;
 use Ray\Di\Injector;
 use Ray\MediaQuery\Queries\TodoAffectedInterface;
 use Ray\MediaQuery\Result\AffectedRows;
+use Ray\MediaQuery\Result\InsertedRow;
 
 use function dirname;
 use function file_get_contents;
@@ -45,7 +46,6 @@ class DbQueryAffectedRowsTest extends TestCase
         $this->assertInstanceOf(AffectedRows::class, $result);
         $this->assertSame(1, $result->count);
         $this->assertTrue($result->isAffected());
-        $this->assertNull($result->lastInsertId);
     }
 
     public function testDeleteMissing(): void
@@ -54,27 +54,27 @@ class DbQueryAffectedRowsTest extends TestCase
         $result = $repo->delete('__missing__');
         $this->assertSame(0, $result->count);
         $this->assertFalse($result->isAffected());
-        $this->assertNull($result->lastInsertId);
     }
 
     public function testUpdate(): void
     {
         $repo = $this->injector->getInstance(TodoAffectedInterface::class);
         $result = $repo->update('1', 'walk');
+        $this->assertInstanceOf(AffectedRows::class, $result);
         $this->assertSame(1, $result->count);
-        $this->assertNull($result->lastInsertId);
     }
 
-    public function testInsertReturnsLastInsertId(): void
+    public function testInsertReturnsResolvedValuesAndId(): void
     {
         $repo = $this->injector->getInstance(TodoAffectedInterface::class);
         $first = $repo->addCounter('alpha');
-        $this->assertSame(1, $first->count);
-        $this->assertSame('1', $first->lastInsertId);
+        $this->assertInstanceOf(InsertedRow::class, $first);
+        $this->assertSame(['label' => 'alpha'], $first->values);
+        $this->assertSame('1', $first->id);
 
         $second = $repo->addCounter('beta');
-        $this->assertSame(1, $second->count);
-        $this->assertSame('2', $second->lastInsertId);
+        $this->assertSame(['label' => 'beta'], $second->values);
+        $this->assertSame('2', $second->id);
     }
 
     public function testMultiStatementReflectsLastStatementOnly(): void
@@ -83,9 +83,9 @@ class DbQueryAffectedRowsTest extends TestCase
         // multi_statement_affected.sql runs:
         //   1) UPDATE todo ... WHERE id = '__missing__'  (0 rows)
         //   2) INSERT INTO counter (label) VALUES ('multi') (1 row, autoincrement id)
-        // AffectedRows must reflect the last (INSERT), not the first (UPDATE).
+        // InsertedRow must reflect the last (INSERT), not the first (UPDATE).
         $result = $repo->multiStatement();
-        $this->assertSame(1, $result->count);
-        $this->assertNotNull($result->lastInsertId);
+        $this->assertInstanceOf(InsertedRow::class, $result);
+        $this->assertNotNull($result->id);
     }
 }

--- a/tests/DbQueryAffectedRowsTest.php
+++ b/tests/DbQueryAffectedRowsTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+
+use Aura\Sql\ExtendedPdoInterface;
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Ray\AuraSqlModule\AuraSqlModule;
+use Ray\Di\Injector;
+use Ray\MediaQuery\Queries\TodoAffectedInterface;
+use Ray\MediaQuery\Result\AffectedRows;
+
+use function dirname;
+use function file_get_contents;
+
+class DbQueryAffectedRowsTest extends TestCase
+{
+    private Injector $injector;
+
+    protected function setUp(): void
+    {
+        $mediaQueries = Queries::fromClasses([
+            TodoAffectedInterface::class,
+        ]);
+        $sqlDir = dirname(__DIR__) . '/tests/sql';
+        $dbQueryConfig = new DbQueryConfig($sqlDir);
+        $module = new MediaQueryModule(
+            $mediaQueries,
+            [$dbQueryConfig],
+            new AuraSqlModule('sqlite::memory:', '', '', '', [PDO::ATTR_STRINGIFY_FETCHES => true]), // @phpstan-ignore-line
+        );
+        $this->injector = new Injector($module, __DIR__ . '/tmp');
+        $pdo = $this->injector->getInstance(ExtendedPdoInterface::class);
+        $pdo->query((string) file_get_contents($sqlDir . '/create_todo.sql'));
+        $pdo->query((string) file_get_contents($sqlDir . '/create_counter.sql'));
+        $pdo->perform((string) file_get_contents($sqlDir . '/todo_add.sql'), ['id' => '1', 'title' => 'run']);
+    }
+
+    public function testDeleteExisting(): void
+    {
+        $repo = $this->injector->getInstance(TodoAffectedInterface::class);
+        $result = $repo->delete('1');
+        $this->assertInstanceOf(AffectedRows::class, $result);
+        $this->assertSame(1, $result->count);
+        $this->assertTrue($result->isAffected());
+        $this->assertNull($result->lastInsertId);
+    }
+
+    public function testDeleteMissing(): void
+    {
+        $repo = $this->injector->getInstance(TodoAffectedInterface::class);
+        $result = $repo->delete('__missing__');
+        $this->assertSame(0, $result->count);
+        $this->assertFalse($result->isAffected());
+        $this->assertNull($result->lastInsertId);
+    }
+
+    public function testUpdate(): void
+    {
+        $repo = $this->injector->getInstance(TodoAffectedInterface::class);
+        $result = $repo->update('1', 'walk');
+        $this->assertSame(1, $result->count);
+        $this->assertNull($result->lastInsertId);
+    }
+
+    public function testInsertReturnsLastInsertId(): void
+    {
+        $repo = $this->injector->getInstance(TodoAffectedInterface::class);
+        $first = $repo->addCounter('alpha');
+        $this->assertSame(1, $first->count);
+        $this->assertSame('1', $first->lastInsertId);
+
+        $second = $repo->addCounter('beta');
+        $this->assertSame(1, $second->count);
+        $this->assertSame('2', $second->lastInsertId);
+    }
+}

--- a/tests/DbQueryAffectedRowsTest.php
+++ b/tests/DbQueryAffectedRowsTest.php
@@ -76,4 +76,16 @@ class DbQueryAffectedRowsTest extends TestCase
         $this->assertSame(1, $second->count);
         $this->assertSame('2', $second->lastInsertId);
     }
+
+    public function testMultiStatementReflectsLastStatementOnly(): void
+    {
+        $repo = $this->injector->getInstance(TodoAffectedInterface::class);
+        // multi_statement_affected.sql runs:
+        //   1) UPDATE todo ... WHERE id = '__missing__'  (0 rows)
+        //   2) INSERT INTO counter (label) VALUES ('multi') (1 row, autoincrement id)
+        // AffectedRows must reflect the last (INSERT), not the first (UPDATE).
+        $result = $repo->multiStatement();
+        $this->assertSame(1, $result->count);
+        $this->assertNotNull($result->lastInsertId);
+    }
 }

--- a/tests/DbQueryCustomPostQueryTest.php
+++ b/tests/DbQueryCustomPostQueryTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+
+use Aura\Sql\ExtendedPdoInterface;
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Ray\AuraSqlModule\AuraSqlModule;
+use Ray\Di\Injector;
+use Ray\MediaQuery\Queries\TodoCustomPostQueryInterface;
+use Ray\MediaQuery\Result\RowCountWithQuery;
+
+use function dirname;
+use function file_get_contents;
+
+class DbQueryCustomPostQueryTest extends TestCase
+{
+    public function testUserDefinedPostQueryIsDispatched(): void
+    {
+        $mediaQueries = Queries::fromClasses([
+            TodoCustomPostQueryInterface::class,
+        ]);
+        $sqlDir = dirname(__DIR__) . '/tests/sql';
+        $dbQueryConfig = new DbQueryConfig($sqlDir);
+        $module = new MediaQueryModule(
+            $mediaQueries,
+            [$dbQueryConfig],
+            new AuraSqlModule('sqlite::memory:', '', '', '', [PDO::ATTR_STRINGIFY_FETCHES => true]), // @phpstan-ignore-line
+        );
+        $injector = new Injector($module, __DIR__ . '/tmp');
+        $pdo = $injector->getInstance(ExtendedPdoInterface::class);
+        $pdo->query((string) file_get_contents($sqlDir . '/create_todo.sql'));
+        $pdo->perform((string) file_get_contents($sqlDir . '/todo_add.sql'), ['id' => '1', 'title' => 'run']);
+
+        $repo = $injector->getInstance(TodoCustomPostQueryInterface::class);
+        $result = $repo->delete('1');
+
+        $this->assertInstanceOf(RowCountWithQuery::class, $result);
+        $this->assertSame(1, $result->count);
+        $this->assertStringContainsStringIgnoringCase('delete', $result->queryString);
+    }
+}

--- a/tests/Fake/FakeSqlQuery.php
+++ b/tests/Fake/FakeSqlQuery.php
@@ -45,7 +45,7 @@ final class FakeSqlQuery implements SqlQueryInterface
      *
      * @param array<string, mixed> $values
      */
-    public function getAffectedRows(string $sqlId, array $values = []): AffectedRows
+    public function execAffected(string $sqlId, array $values = []): AffectedRows
     {
         return new AffectedRows(0);
     }

--- a/tests/Fake/FakeSqlQuery.php
+++ b/tests/Fake/FakeSqlQuery.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Ray\MediaQuery;
 
+use Ray\MediaQuery\Result\AffectedRows;
+
 final class FakeSqlQuery implements SqlQueryInterface
 {
     /** @var list<int> */
@@ -36,6 +38,16 @@ final class FakeSqlQuery implements SqlQueryInterface
      */
     public function exec(string $sqlId, array $values = [], FetchInterface|null $fetch = null): void
     {
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param array<string, mixed> $values
+     */
+    public function getAffectedRows(string $sqlId, array $values = []): AffectedRows
+    {
+        return new AffectedRows(0);
     }
 
     /**

--- a/tests/Fake/FakeSqlQuery.php
+++ b/tests/Fake/FakeSqlQuery.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Ray\MediaQuery;
 
-use Ray\MediaQuery\Result\AffectedRows;
+use LogicException;
+use Ray\MediaQuery\Result\PostQueryInterface;
 
 final class FakeSqlQuery implements SqlQueryInterface
 {
@@ -45,9 +46,9 @@ final class FakeSqlQuery implements SqlQueryInterface
      *
      * @param array<string, mixed> $values
      */
-    public function execAffected(string $sqlId, array $values = []): AffectedRows
+    public function execPostQuery(string $sqlId, array $values, string $postQueryClass): PostQueryInterface
     {
-        return new AffectedRows(0);
+        throw new LogicException('FakeSqlQuery does not support execPostQuery');
     }
 
     /**

--- a/tests/Fake/Queries/TodoAffectedInterface.php
+++ b/tests/Fake/Queries/TodoAffectedInterface.php
@@ -17,4 +17,7 @@ interface TodoAffectedInterface
 
     #[DbQuery('counter_add')]
     public function addCounter(string $label): AffectedRows;
+
+    #[DbQuery('multi_statement_affected')]
+    public function multiStatement(): AffectedRows;
 }

--- a/tests/Fake/Queries/TodoAffectedInterface.php
+++ b/tests/Fake/Queries/TodoAffectedInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery\Queries;
+
+use Ray\MediaQuery\Annotation\DbQuery;
+use Ray\MediaQuery\Result\AffectedRows;
+
+interface TodoAffectedInterface
+{
+    #[DbQuery('todo_delete')]
+    public function delete(string $id): AffectedRows;
+
+    #[DbQuery('todo_update')]
+    public function update(string $id, string $title): AffectedRows;
+
+    #[DbQuery('counter_add')]
+    public function addCounter(string $label): AffectedRows;
+}

--- a/tests/Fake/Queries/TodoAffectedInterface.php
+++ b/tests/Fake/Queries/TodoAffectedInterface.php
@@ -6,6 +6,7 @@ namespace Ray\MediaQuery\Queries;
 
 use Ray\MediaQuery\Annotation\DbQuery;
 use Ray\MediaQuery\Result\AffectedRows;
+use Ray\MediaQuery\Result\InsertedRow;
 
 interface TodoAffectedInterface
 {
@@ -16,8 +17,8 @@ interface TodoAffectedInterface
     public function update(string $id, string $title): AffectedRows;
 
     #[DbQuery('counter_add')]
-    public function addCounter(string $label): AffectedRows;
+    public function addCounter(string $label): InsertedRow;
 
     #[DbQuery('multi_statement_affected')]
-    public function multiStatement(): AffectedRows;
+    public function multiStatement(): InsertedRow;
 }

--- a/tests/Fake/Queries/TodoCustomPostQueryInterface.php
+++ b/tests/Fake/Queries/TodoCustomPostQueryInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery\Queries;
+
+use Ray\MediaQuery\Annotation\DbQuery;
+use Ray\MediaQuery\Result\RowCountWithQuery;
+
+interface TodoCustomPostQueryInterface
+{
+    #[DbQuery('todo_delete')]
+    public function delete(string $id): RowCountWithQuery;
+}

--- a/tests/Fake/Result/RowCountWithQuery.php
+++ b/tests/Fake/Result/RowCountWithQuery.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery\Result;
+
+use Override;
+
+final class RowCountWithQuery implements PostQueryInterface
+{
+    public function __construct(
+        public readonly int $count,
+        public readonly string $queryString,
+    ) {
+    }
+
+    #[Override]
+    public static function postQuery(PostQueryContext $context): static
+    {
+        return new static($context->statement->rowCount(), $context->statement->queryString);
+    }
+}

--- a/tests/Fake/Result/RowCountWithQuery.php
+++ b/tests/Fake/Result/RowCountWithQuery.php
@@ -15,7 +15,7 @@ final class RowCountWithQuery implements PostQueryInterface
     }
 
     #[Override]
-    public static function postQuery(PostQueryContext $context): static
+    public static function fromContext(PostQueryContext $context): static
     {
         return new static($context->statement->rowCount(), $context->statement->queryString);
     }

--- a/tests/SqlQueryTest.php
+++ b/tests/SqlQueryTest.php
@@ -19,6 +19,7 @@ use Ray\InputQuery\ToArray;
 use Ray\MediaQuery\Exception\InvalidSqlException;
 use Ray\MediaQuery\Exception\LogicException;
 use Ray\MediaQuery\Exception\PdoPerformException;
+use Ray\MediaQuery\Result\AffectedRows;
 
 use function count;
 use function file_get_contents;
@@ -37,6 +38,7 @@ class SqlQueryTest extends TestCase
         $pdo = new ExtendedPdo('sqlite::memory:', '', '', [PDO::ATTR_STRINGIFY_FETCHES => true]);
         $pdo->query((string) file_get_contents($sqlDir . '/create_todo.sql'));
         $pdo->query((string) file_get_contents($sqlDir . '/create_promise.sql'));
+        $pdo->query((string) file_get_contents($sqlDir . '/create_counter.sql'));
         $pdo->perform((string) file_get_contents($sqlDir . '/todo_add.sql'), $this->insertData);
         $this->log = new MediaQueryLogger();
         $this->sqlQuery = new SqlQuery(
@@ -167,5 +169,29 @@ class SqlQueryTest extends TestCase
     {
         $this->expectException(PdoPerformException::class);
         $this->sqlQuery->getRowList('error_list', []);
+    }
+
+    public function testGetAffectedRowsForDelete(): void
+    {
+        $result = $this->sqlQuery->getAffectedRows('todo_delete', ['id' => '1']);
+        $this->assertInstanceOf(AffectedRows::class, $result);
+        $this->assertSame(1, $result->count);
+        $this->assertTrue($result->isAffected());
+        $this->assertNull($result->lastInsertId);
+    }
+
+    public function testGetAffectedRowsForDeleteMissing(): void
+    {
+        $result = $this->sqlQuery->getAffectedRows('todo_delete', ['id' => '__missing__']);
+        $this->assertSame(0, $result->count);
+        $this->assertFalse($result->isAffected());
+        $this->assertNull($result->lastInsertId);
+    }
+
+    public function testGetAffectedRowsForInsertReturnsLastInsertId(): void
+    {
+        $result = $this->sqlQuery->getAffectedRows('counter_add', ['label' => 'first']);
+        $this->assertSame(1, $result->count);
+        $this->assertSame('1', $result->lastInsertId);
     }
 }

--- a/tests/SqlQueryTest.php
+++ b/tests/SqlQueryTest.php
@@ -20,6 +20,7 @@ use Ray\MediaQuery\Exception\InvalidSqlException;
 use Ray\MediaQuery\Exception\LogicException;
 use Ray\MediaQuery\Exception\PdoPerformException;
 use Ray\MediaQuery\Result\AffectedRows;
+use Ray\MediaQuery\Result\InsertedRow;
 
 use function count;
 use function file_get_contents;
@@ -171,27 +172,27 @@ class SqlQueryTest extends TestCase
         $this->sqlQuery->getRowList('error_list', []);
     }
 
-    public function testExecAffectedForDelete(): void
+    public function testExecPostQueryForDelete(): void
     {
-        $result = $this->sqlQuery->execAffected('todo_delete', ['id' => '1']);
+        $result = $this->sqlQuery->execPostQuery('todo_delete', ['id' => '1'], AffectedRows::class);
         $this->assertInstanceOf(AffectedRows::class, $result);
         $this->assertSame(1, $result->count);
         $this->assertTrue($result->isAffected());
-        $this->assertNull($result->lastInsertId);
     }
 
-    public function testExecAffectedForDeleteMissing(): void
+    public function testExecPostQueryForDeleteMissing(): void
     {
-        $result = $this->sqlQuery->execAffected('todo_delete', ['id' => '__missing__']);
+        $result = $this->sqlQuery->execPostQuery('todo_delete', ['id' => '__missing__'], AffectedRows::class);
+        $this->assertInstanceOf(AffectedRows::class, $result);
         $this->assertSame(0, $result->count);
         $this->assertFalse($result->isAffected());
-        $this->assertNull($result->lastInsertId);
     }
 
-    public function testExecAffectedForInsertReturnsLastInsertId(): void
+    public function testExecPostQueryForInsertReturnsResolvedValuesAndId(): void
     {
-        $result = $this->sqlQuery->execAffected('counter_add', ['label' => 'first']);
-        $this->assertSame(1, $result->count);
-        $this->assertSame('1', $result->lastInsertId);
+        $result = $this->sqlQuery->execPostQuery('counter_add', ['label' => 'first'], InsertedRow::class);
+        $this->assertInstanceOf(InsertedRow::class, $result);
+        $this->assertSame(['label' => 'first'], $result->values);
+        $this->assertSame('1', $result->id);
     }
 }

--- a/tests/SqlQueryTest.php
+++ b/tests/SqlQueryTest.php
@@ -171,26 +171,26 @@ class SqlQueryTest extends TestCase
         $this->sqlQuery->getRowList('error_list', []);
     }
 
-    public function testGetAffectedRowsForDelete(): void
+    public function testExecAffectedForDelete(): void
     {
-        $result = $this->sqlQuery->getAffectedRows('todo_delete', ['id' => '1']);
+        $result = $this->sqlQuery->execAffected('todo_delete', ['id' => '1']);
         $this->assertInstanceOf(AffectedRows::class, $result);
         $this->assertSame(1, $result->count);
         $this->assertTrue($result->isAffected());
         $this->assertNull($result->lastInsertId);
     }
 
-    public function testGetAffectedRowsForDeleteMissing(): void
+    public function testExecAffectedForDeleteMissing(): void
     {
-        $result = $this->sqlQuery->getAffectedRows('todo_delete', ['id' => '__missing__']);
+        $result = $this->sqlQuery->execAffected('todo_delete', ['id' => '__missing__']);
         $this->assertSame(0, $result->count);
         $this->assertFalse($result->isAffected());
         $this->assertNull($result->lastInsertId);
     }
 
-    public function testGetAffectedRowsForInsertReturnsLastInsertId(): void
+    public function testExecAffectedForInsertReturnsLastInsertId(): void
     {
-        $result = $this->sqlQuery->getAffectedRows('counter_add', ['label' => 'first']);
+        $result = $this->sqlQuery->execAffected('counter_add', ['label' => 'first']);
         $this->assertSame(1, $result->count);
         $this->assertSame('1', $result->lastInsertId);
     }

--- a/tests/sql/counter_add.sql
+++ b/tests/sql/counter_add.sql
@@ -1,0 +1,1 @@
+INSERT INTO counter (label) VALUES (:label);

--- a/tests/sql/create_counter.sql
+++ b/tests/sql/create_counter.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS counter
+(
+    id    INTEGER PRIMARY KEY AUTOINCREMENT,
+    label TEXT
+)

--- a/tests/sql/multi_statement_affected.sql
+++ b/tests/sql/multi_statement_affected.sql
@@ -1,0 +1,2 @@
+UPDATE todo SET title = 'never' WHERE id = '__missing__';
+INSERT INTO counter (label) VALUES ('multi');

--- a/tests/sql/todo_delete.sql
+++ b/tests/sql/todo_delete.sql
@@ -1,0 +1,1 @@
+DELETE FROM todo WHERE id = :id;

--- a/tests/sql/todo_update.sql
+++ b/tests/sql/todo_update.sql
@@ -1,0 +1,1 @@
+UPDATE todo SET title = :title WHERE id = :id;


### PR DESCRIPTION
## Summary

- Introduce `Ray\MediaQuery\Result\PostQueryInterface` — a single static factory (`fromContext(PostQueryContext $context): static`) that result classes implement. `DbQueryInterceptor` dispatches polymorphically on the declared return type, so user-defined result types plug in without touching framework code.
- Ship two framework result types:
  - `AffectedRows` — row count for `UPDATE` / `DELETE` (`count`, `isAffected()`).
  - `InsertedRow` — the **resolved parameter values** (`values`) plus the auto-increment `id` for `INSERT`. The resolved values are Ray.MediaQuery's unique value-add (UUID / timestamp injection, `DateTime`→SQL string, `ToScalarInterface` reduction) and are not otherwise observable by the caller.
- Replace `SqlQueryInterface::execAffected()` with the generic `execPostQuery(sqlId, values, postQueryClass)`. The caller's return-type declaration is the intent declaration — no SQL-string sniffing.
- `PostQueryContext` carries the executed `PDOStatement`, the `ExtendedPdoInterface`, and the resolved values to the factory; future extensions add fields to the context instead of breaking the interface.

Refs #84 (first of two parts — `Traversable` auto-wrap is a planned follow-up).

## Usage

```php
use Ray\MediaQuery\Result\AffectedRows;
use Ray\MediaQuery\Result\InsertedRow;

interface ArticleRepositoryInterface
{
    #[DbQuery('article_delete')]
    public function delete(string $id): AffectedRows;

    #[DbQuery('article_insert')]
    public function create(string $title): InsertedRow;
}

$result = $repo->delete($id);
if (! $result->isAffected()) {
    throw new NotFoundException($id);
}

$inserted = $repo->create('Hello');
$inserted->values;  // array<string, mixed> — parameters as bound to the driver
$inserted->id;      // ?string — auto-increment id (null if the driver reports none)
```

### Custom result types

```php
use Ray\MediaQuery\Result\PostQueryContext;
use Ray\MediaQuery\Result\PostQueryInterface;

final class RowCountWithQuery implements PostQueryInterface
{
    public function __construct(
        public readonly int $count,
        public readonly string $queryString,
    ) {}

    public static function fromContext(PostQueryContext $context): static
    {
        return new static($context->statement->rowCount(), $context->statement->queryString);
    }
}
```

Declare it on any `#[DbQuery]` method and the interceptor dispatches to its factory.

## Design notes

- **No SQL-string sniffing.** The previous design bundled `count + lastInsertId` in one class, which forced `SqlQuery` to parse the query string to decide whether to call `lastInsertId()`. With two typed results, the caller declares intent and the framework trusts it — same pattern as Laravel's `Connection::insert/update/delete` and Doctrine DBAL's typed helpers.
- **`InsertedRow` carries resolved values, not count.** For `INSERT` the count is almost always trivially 1; the genuinely useful observation is what the framework *actually bound* to the driver after UUID / timestamp / `DateTime` / `ToScalar` resolution. That's the framework's unique contribution and not otherwise visible to the caller.
- **`lastInsertId` (`InsertedRow::$id`) normalisation** — PDO values of `false` / `''` / `'0'` become `null`, so `if ($result->id !== null)` stays ergonomic.
- **Multi-statement SQL** — the result reflects the last executed statement only.
- **Trust model** — wiring `InsertedRow` to a non-INSERT statement is a caller error; `lastInsertId()` may return a stale session value. Consistent with typed DML APIs in Laravel / Doctrine.

## Test plan

- [x] `composer cs` passes
- [x] `composer sa` (Psalm + PHPStan level max) passes
- [x] `composer test` — 96 tests, 155 assertions, all green
- [x] `DbQueryAffectedRowsTest` covers DELETE (hit / miss), UPDATE (`AffectedRows`), INSERT (`InsertedRow` with resolved values + id), and multi-statement last-statement semantics
- [x] `SqlQueryTest` extended with direct `execPostQuery()` cases for both result types
- [x] New `DbQueryCustomPostQueryTest` proves the extension point: a user-defined `RowCountWithQuery` implementing `PostQueryInterface` is dispatched via the same polymorphic path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DML operations (INSERT, UPDATE, DELETE) now return typed result objects: `AffectedRows` (row count + `isAffected()` helper) and `InsertedRow` (bound parameters + auto-increment id).
  * Custom post-query result types supported via `PostQueryInterface` implementation.
  * New `execPostQuery()` method for direct SQL execution with typed results.
  * Multi-statement SQL returns results reflecting only the final statement.

* **Documentation**
  * Updated README with DML return type examples and custom result type creation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
