### PR TITLE
Collection return type auto-wrap (part 2 of #84)

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,34 @@ $result->isAffected();  // bool — true when count > 0
 
 When a SQL file contains multiple statements (separated by `;`), `AffectedRows` reflects the **last executed statement only**.
 
+**Collection Return Type (auto-wrap):**
+
+Declare any Traversable class as the return type and Ray.MediaQuery will instantiate it with the row list:
+
+```php
+interface UserRepository
+{
+    #[DbQuery('user_list')]
+    public function list(): UserCollection;  // raw associative arrays
+
+    #[DbQuery('user_list', factory: UserFactory::class)]
+    public function hydrated(): UserCollection;  // User instances
+
+    #[DbQuery('user_list')]
+    /** @return UserCollection<User> */
+    public function byDocblock(): UserCollection;  // User instances via docblock hint
+}
+
+final class UserCollection implements IteratorAggregate, Countable
+{
+    public function __construct(public readonly array $items) {}
+    public function getIterator(): ArrayIterator { return new ArrayIterator($this->items); }
+    public function count(): int { return count($this->items); }
+}
+```
+
+A class qualifies for auto-wrap when it implements `Traversable`, is instantiable, and has at least one constructor parameter. This covers PHP's built-in `ArrayObject`, Laravel `Illuminate\Support\Collection`, Doctrine `ArrayCollection`, and any user-defined collection. The items passed to the constructor are entity-hydrated when `factory:` or a `@return Collection<Entity>` docblock resolves to an entity class; otherwise raw associative arrays are passed.
+
 **Constructor Property Promotion (Recommended):**
 
 Use constructor property promotion for type-safe, immutable entities:

--- a/src/CollectionTypeResolver.php
+++ b/src/CollectionTypeResolver.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+
+use ReflectionClass;
+use Traversable;
+
+use function class_exists;
+
+final class CollectionTypeResolver
+{
+    public static function isCollection(string $type): bool
+    {
+        if (! class_exists($type)) {
+            return false;
+        }
+
+        $rc = new ReflectionClass($type);
+        if (! $rc->isInstantiable() || ! $rc->implementsInterface(Traversable::class)) {
+            return false;
+        }
+
+        $ctor = $rc->getConstructor();
+
+        return $ctor !== null && $ctor->getNumberOfParameters() >= 1;
+    }
+}

--- a/src/DbQueryInterceptor.php
+++ b/src/DbQueryInterceptor.php
@@ -12,6 +12,7 @@ use Ray\Di\ProviderInterface;
 use Ray\MediaQuery\Annotation\DbQuery;
 use Ray\MediaQuery\Annotation\Pager;
 use Ray\MediaQuery\Result\AffectedRows;
+use ReflectionClass;
 use ReflectionNamedType;
 use ReflectionUnionType;
 
@@ -30,7 +31,7 @@ final class DbQueryInterceptor implements MethodInterceptor
     ) {
     }
 
-    /** @return array<mixed>|object|null */
+    /** @return array<mixed>|object|AffectedRows|null */
     #[Override]
     public function invoke(MethodInvocation $invocation): array|object|null
     {
@@ -50,6 +51,16 @@ final class DbQueryInterceptor implements MethodInterceptor
         assert($returnType === null || $returnType instanceof ReflectionNamedType || $returnType instanceof ReflectionUnionType);
         if ($returnType instanceof ReflectionNamedType && $returnType->getName() === AffectedRows::class) {
             return $this->sqlQuery->execAffected($dbQuery->id, $values);
+        }
+
+        if ($returnType instanceof ReflectionNamedType && CollectionTypeResolver::isCollection($returnType->getName())) {
+            $fetch = $this->factory->factory($dbQuery, $entity, $returnType);
+            /** @var array<mixed> $rows */
+            $rows = $this->sqlQuery->getRowList($dbQuery->id, $values, $fetch);
+            /** @var class-string $class */
+            $class = $returnType->getName();
+
+            return (new ReflectionClass($class))->newInstanceArgs([$rows]);
         }
 
         $fetch = $this->factory->factory($dbQuery, $entity, $returnType);

--- a/src/ReturnEntity.php
+++ b/src/ReturnEntity.php
@@ -40,7 +40,7 @@ final class ReturnEntity implements ReturnEntityInterface
 
         $returnTypeClass = $this->getReturnTypeName($returnType);
 
-        if (class_exists($returnTypeClass) && ! is_a($returnTypeClass, PagesInterface::class, true)) {
+        if (class_exists($returnTypeClass) && ! is_a($returnTypeClass, PagesInterface::class, true) && ! CollectionTypeResolver::isCollection($returnTypeClass)) {
             return $returnTypeClass;
         }
 

--- a/tests/CollectionTypeResolverTest.php
+++ b/tests/CollectionTypeResolverTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+
+use ArrayObject;
+use Generator;
+use PHPUnit\Framework\TestCase;
+use SplObjectStorage;
+use stdClass;
+
+class CollectionTypeResolverTest extends TestCase
+{
+    public function testArrayObjectIsCollection(): void
+    {
+        $this->assertTrue(CollectionTypeResolver::isCollection(ArrayObject::class));
+    }
+
+    public function testFakeTodoCollectionIsCollection(): void
+    {
+        $this->assertTrue(CollectionTypeResolver::isCollection(FakeTodoCollection::class));
+    }
+
+    public function testStdClassIsNotCollection(): void
+    {
+        $this->assertFalse(CollectionTypeResolver::isCollection(stdClass::class));
+    }
+
+    public function testGeneratorIsNotCollection(): void
+    {
+        $this->assertFalse(CollectionTypeResolver::isCollection(Generator::class));
+    }
+
+    public function testNonExistentClassIsNotCollection(): void
+    {
+        $this->assertFalse(CollectionTypeResolver::isCollection('NonExistentClass'));
+    }
+
+    public function testPagesIsNotCollection(): void
+    {
+        $this->assertFalse(CollectionTypeResolver::isCollection(Pages::class));
+    }
+
+    public function testZeroArgConstructorIsNotCollection(): void
+    {
+        // SplObjectStorage implements Iterator but has no constructor params
+        $this->assertFalse(CollectionTypeResolver::isCollection(SplObjectStorage::class));
+    }
+}

--- a/tests/DbQueryCollectionTest.php
+++ b/tests/DbQueryCollectionTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+
+use Aura\Sql\ExtendedPdoInterface;
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Ray\AuraSqlModule\AuraSqlModule;
+use Ray\Di\AbstractModule;
+use Ray\Di\Injector;
+use Ray\MediaQuery\Entity\Todo;
+use Ray\MediaQuery\Entity\TodoConstruct;
+use Ray\MediaQuery\Factory\FakeFactoryHelper;
+use Ray\MediaQuery\Factory\FakeFactoryHelperInterface;
+use Ray\MediaQuery\Fake\Queries\TodoCollectionInterface;
+
+use function dirname;
+use function file_get_contents;
+
+class DbQueryCollectionTest extends TestCase
+{
+    private Injector $injector;
+
+    protected function setUp(): void
+    {
+        $mediaQueries = Queries::fromClasses([
+            TodoCollectionInterface::class,
+        ]);
+        $sqlDir = dirname(__DIR__) . '/tests/sql';
+        $dbQueryConfig = new DbQueryConfig($sqlDir);
+        $module = new MediaQueryModule(
+            $mediaQueries,
+            [$dbQueryConfig],
+            new AuraSqlModule(
+                'sqlite::memory:',
+                '',
+                '',
+                '',
+                [PDO::ATTR_STRINGIFY_FETCHES => true], // @phpstan-ignore-line
+            ),
+        );
+        $module->install(new class extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->bind(FakeFactoryHelperInterface::class)->to(FakeFactoryHelper::class);
+            }
+        });
+        $this->injector = new Injector($module, __DIR__ . '/tmp');
+        $pdo = $this->injector->getInstance(ExtendedPdoInterface::class);
+        $pdo->query((string) file_get_contents($sqlDir . '/create_todo.sql'));
+        $pdo->perform((string) file_get_contents($sqlDir . '/todo_add.sql'), ['id' => '1', 'title' => 'run']);
+    }
+
+    public function testListReturnsCollectionOfAssocArrays(): void
+    {
+        $repo = $this->injector->getInstance(TodoCollectionInterface::class);
+        $result = $repo->list();
+        $this->assertInstanceOf(FakeTodoCollection::class, $result);
+        $items = $result->items;
+        $this->assertIsArray($items[0]);
+        $this->assertSame('1', $items[0]['id']);
+        $this->assertSame('run', $items[0]['title']);
+    }
+
+    public function testHydratedReturnsCollectionOfEntities(): void
+    {
+        $repo = $this->injector->getInstance(TodoCollectionInterface::class);
+        $result = $repo->hydrated();
+        $this->assertInstanceOf(FakeTodoCollection::class, $result);
+        $this->assertInstanceOf(TodoConstruct::class, $result->items[0]);
+        $this->assertSame('run', $result->items[0]->title);
+    }
+
+    public function testDocblockEntityReturnsCollectionOfTodo(): void
+    {
+        $repo = $this->injector->getInstance(TodoCollectionInterface::class);
+        $result = $repo->docblockEntity();
+        $this->assertInstanceOf(FakeTodoCollection::class, $result);
+        $this->assertInstanceOf(Todo::class, $result->items[0]);
+        $this->assertSame('run', $result->items[0]->title);
+    }
+
+    public function testUntypedCollectionConstructedSuccessfully(): void
+    {
+        $repo = $this->injector->getInstance(TodoCollectionInterface::class);
+        $result = $repo->untyped();
+        $this->assertInstanceOf(FakeUntypedCollection::class, $result);
+        $this->assertNotEmpty($result->items);
+    }
+
+    public function testHydratedCollectionIsCountableAndTraversable(): void
+    {
+        $repo = $this->injector->getInstance(TodoCollectionInterface::class);
+        $result = $repo->hydrated();
+        $this->assertCount(1, $result);
+        $items = [];
+        foreach ($result as $item) {
+            $items[] = $item;
+        }
+
+        $this->assertCount(1, $items);
+        $this->assertInstanceOf(TodoConstruct::class, $items[0]);
+    }
+}

--- a/tests/Fake/FakeTodoCollection.php
+++ b/tests/Fake/FakeTodoCollection.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+
+use ArrayIterator;
+use Countable;
+use IteratorAggregate;
+use Traversable;
+
+/**
+ * Minimal domain-specific collection for testing Collection return type auto-wrap.
+ *
+ * @implements IteratorAggregate<int, mixed>
+ */
+final class FakeTodoCollection implements IteratorAggregate, Countable
+{
+    public function __construct(public readonly array $items)
+    {
+    }
+
+    /** @return Traversable<int, mixed> */
+    #[\Override]
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->items);
+    }
+
+    #[\Override]
+    public function count(): int
+    {
+        return count($this->items);
+    }
+}

--- a/tests/Fake/FakeUntypedCollection.php
+++ b/tests/Fake/FakeUntypedCollection.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+
+use ArrayIterator;
+use Countable;
+use IteratorAggregate;
+use Traversable;
+
+/**
+ * Laravel-style collection with an untyped constructor parameter.
+ *
+ * @implements IteratorAggregate<int, mixed>
+ */
+final class FakeUntypedCollection implements IteratorAggregate, Countable
+{
+    /** @var array<mixed> */
+    public readonly array $items;
+
+    /** @param mixed $items */
+    public function __construct($items = [])
+    {
+        $this->items = (array) $items;
+    }
+
+    /** @return Traversable<int, mixed> */
+    #[\Override]
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->items);
+    }
+
+    #[\Override]
+    public function count(): int
+    {
+        return count($this->items);
+    }
+}

--- a/tests/Fake/Queries/TodoCollectionInterface.php
+++ b/tests/Fake/Queries/TodoCollectionInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery\Fake\Queries;
+
+use Ray\MediaQuery\Annotation\DbQuery;
+use Ray\MediaQuery\Entity\Todo;
+use Ray\MediaQuery\Factory\TodoEntityFactory;
+use Ray\MediaQuery\FakeTodoCollection;
+use Ray\MediaQuery\FakeUntypedCollection;
+
+interface TodoCollectionInterface
+{
+    /** Returns FakeTodoCollection containing raw associative arrays. */
+    #[DbQuery('todo_list')]
+    public function list(): FakeTodoCollection;
+
+    /** Returns FakeTodoCollection containing TodoConstruct instances via static factory. */
+    #[DbQuery('todo_list', factory: TodoEntityFactory::class)]
+    public function hydrated(): FakeTodoCollection;
+
+    /**
+     * Returns FakeTodoCollection containing Todo instances via docblock entity.
+     *
+     * @return FakeTodoCollection<Todo>
+     */
+    #[DbQuery('todo_list')]
+    public function docblockEntity(): FakeTodoCollection;
+
+    /** Returns FakeUntypedCollection (Laravel-style untyped constructor). */
+    #[DbQuery('todo_list')]
+    public function untyped(): FakeUntypedCollection;
+}


### PR DESCRIPTION
## Summary

Part 2 of #84 — stacks on top of #85 (AffectedRows).

Methods annotated with `#[DbQuery]` can now declare any `Traversable` class as the return type. Ray.MediaQuery instantiates the class with the row list, so callers no longer write `new UserCollection($repo->list())` at every call site.

```php
interface UserRepository
{
    #[DbQuery('user_list')]
    public function list(): UserCollection;  // raw assoc arrays

    #[DbQuery('user_list', factory: UserFactory::class)]
    public function hydrated(): UserCollection;  // User instances

    #[DbQuery('user_list')]
    /** @return UserCollection<User> */
    public function byDocblock(): UserCollection;  // User instances via docblock
}
```

### Detection rule

A class qualifies for auto-wrap when it:
1. `implementsInterface(Traversable::class)` (directly or via `IteratorAggregate` / `Iterator`)
2. `ReflectionClass::isInstantiable()`
3. has a constructor with `getNumberOfParameters() >= 1`

The first constructor parameter's type is **not** constrained. This admits:
- Laravel `Illuminate\Support\Collection` (untyped `$items = []`)
- Doctrine `ArrayCollection` (`array $elements`)
- PHP built-in `ArrayObject`
- User-defined classes

### Dispatch order

`DbQueryInterceptor::invoke()` now dispatches in this order:

1. `#[Pager]` → `Pages` (existing)
2. `AffectedRows` return type → `AffectedRows` (from #85)
3. **NEW: Collection-compatible return type → auto-wrapped row list**
4. Existing row / row_list / entity dispatch

### Hydration

Items passed to the constructor are entity-hydrated when `factory:` or a `@return Collection<Entity>` docblock resolves to an entity class; otherwise raw associative arrays are passed.

## Base branch

Targets `affected-rows` to keep the diff focused on this feature. GitHub will re-target to `1.x` automatically when #85 merges.

## Test plan

- [x] `composer cs-fix` clean
- [x] `composer sa` (psalm + phpstan level max) clean, zero new suppressions
- [x] `composer test` — 107/107 tests pass (12 new: 7 unit + 5 integration)
- [x] Laravel-style untyped constructor (`$items = []`) smoke-tested via `FakeUntypedCollection`
- [x] `Pages::class` rejected by `CollectionTypeResolver::isCollection()` (sanity check)

## Out of scope

- `Cell` / `Scalar` / `ColumnList` return types from the original #84 proposal
- Reflection result caching (add if profiling warrants)