### PR TITLE
Unify SELECT / Collection under PostQueryInterface (replaces #87)

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,10 +422,12 @@ final class Users extends TypedRows {}
 `PostQueryInterface` dispatches based on the *last* executed statement, so a single SQL file can run a DML and then expose its result via a trailing SELECT:
 
 ```sql
--- create_article.sql
+-- create_article.sql (SQLite — adjust the second statement per driver)
 INSERT INTO articles (title, body) VALUES (:title, :body);
 SELECT * FROM articles WHERE id = last_insert_rowid();
 ```
+
+The `last_insert_rowid()` call is SQLite-specific. On other drivers, use the equivalent — e.g. `LAST_INSERT_ID()` on MySQL, or fold the SELECT into the INSERT via `INSERT ... RETURNING *` on PostgreSQL / MariaDB / SQLite ≥ 3.35.
 
 ```php
 final class CreatedArticle implements PostQueryInterface
@@ -707,7 +709,7 @@ class CustomRepository
 - `getRow($queryId, $params)` - Single row
 - `getRowList($queryId, $params)` - Multiple rows
 - `exec($queryId, $params)` - Execute without result
-- `execPostQuery($queryId, $params, $postQueryClass, $fetch = null)` - Execute a SQL statement (SELECT or DML) and build a typed result via a `PostQueryInterface` class (e.g. `AffectedRows`, `InsertedRow`, a typed collection wrapper, or any custom class)
+- `execPostQuery($queryId, $params, $postQueryClass, FetchInterface|null $fetch = null)` - Execute a SQL statement (SELECT or DML) and build a typed result via a `PostQueryInterface` class (e.g. `AffectedRows`, `InsertedRow`, a typed collection wrapper, or any custom class). When `$fetch` is supplied, SELECT rows arrive on the context already hydrated to that strategy's shape.
 - `getCount($queryId, $params)` - Total row count (for pagination)
 - `getStatement()` - Get PDO statement
 - `getPages()` - Get paginated results

--- a/README.md
+++ b/README.md
@@ -417,6 +417,42 @@ final class Users extends TypedRows {}
 
 `@extends TypedRows<Article>` carries `Article` through to every site that inspects the rows — `$articles->rows[0]->title`, `foreach ($articles as $a) { $a->wordCount; }`, and any derived method on the base. The framework still hands `$context->rows` as `array<mixed>`; the narrow happens at the `@var list<T>` line in `fromContext()`, and from that point on the static analyser honours the parameter. Runtime is identical to the single-type wrapper above — PHP has no native generics, so this is a static-analysis claim, not a runtime check.
 
+**Multi-statement SQL — DML + SELECT in one method:**
+
+`PostQueryInterface` dispatches based on the *last* executed statement, so a single SQL file can run a DML and then expose its result via a trailing SELECT:
+
+```sql
+-- create_article.sql
+INSERT INTO articles (title, body) VALUES (:title, :body);
+SELECT * FROM articles WHERE id = last_insert_rowid();
+```
+
+```php
+final class CreatedArticle implements PostQueryInterface
+{
+    public function __construct(public readonly Article $article) {}
+
+    public static function fromContext(PostQueryContext $context): static
+    {
+        /** @var list<Article> $rows */
+        $rows = $context->rows;
+
+        return new static($rows[0]);
+    }
+}
+
+interface ArticleRepository
+{
+    /** @return CreatedArticle */
+    #[DbQuery('create_article')]
+    public function create(string $title, string $body): CreatedArticle;
+}
+```
+
+The framework runs both statements in order. The last statement is a SELECT, so `$context->rows` carries its hydrated result — letting a single repository method express "execute and return a typed view of the affected row" without driver-specific `RETURNING`. The same shape rules apply: declare `@return CreatedArticle` (or a generic wrapper) and the trailing SELECT is hydrated to entities; omit it and `$context->rows` arrives as associative arrays.
+
+`$context->rows === []` therefore means "the last statement was DML" or "the last statement was a SELECT that matched nothing" — the distinction is determined by the SQL file you wrote, so each result class is naturally scoped to one of those.
+
 **Constructor Property Promotion (Recommended):**
 
 Use constructor property promotion for type-safe, immutable entities:

--- a/README.md
+++ b/README.md
@@ -311,6 +311,112 @@ final class RowCountWithQuery implements PostQueryInterface
 
 Declare it on any `#[DbQuery]` method and the interceptor dispatches to the class's own factory.
 
+**SELECT collections — typed row wrappers:**
+
+`PostQueryInterface` also covers SELECT. The framework pre-hydrates the result set into `PostQueryContext::$rows` (entity instances when a `factory:` attribute or `@return Wrapper<Entity>` docblock resolves an entity, associative arrays otherwise). Your wrapper class composes those rows — it never touches raw `PDOStatement` or DI:
+
+```php
+use ArrayIterator;
+use Countable;
+use IteratorAggregate;
+use Ray\MediaQuery\Result\PostQueryContext;
+use Ray\MediaQuery\Result\PostQueryInterface;
+
+/** @implements IteratorAggregate<int, Article> */
+final class Articles implements PostQueryInterface, IteratorAggregate, Countable
+{
+    /** @param list<Article> $rows */
+    public function __construct(public readonly array $rows) {}
+
+    public static function fromContext(PostQueryContext $context): static
+    {
+        /** @var list<Article> $rows */
+        $rows = $context->rows;
+
+        return new static($rows);
+    }
+
+    /** Domain predicates / aggregations — the reason to wrap. */
+    public function published(): self
+    {
+        return new self(array_values(array_filter(
+            $this->rows,
+            static fn (Article $a): bool => $a->isPublished(),
+        )));
+    }
+
+    public function totalWordCount(): int
+    {
+        return array_sum(array_map(
+            static fn (Article $a): int => $a->wordCount,
+            $this->rows,
+        ));
+    }
+
+    /** @return ArrayIterator<int, Article> */
+    public function getIterator(): ArrayIterator { return new ArrayIterator($this->rows); }
+    public function count(): int { return count($this->rows); }
+}
+
+interface ArticleRepository
+{
+    /** @return Articles<Article> */
+    #[DbQuery('article_list')]
+    public function list(): Articles;
+}
+```
+
+Callers get `$articles->published()->totalWordCount()` — domain logic about the result set lives on the type, not scattered across services. `IteratorAggregate` / `Countable` give the wrapper standard "feels like an array" ergonomics. To compose a richer base, wrap a Laravel / Illuminate / Doctrine `Collection` via a property the same way.
+
+`$rows` shape is determined by what the framework hands the wrapper:
+
+- `@return Articles<Article>` docblock or `factory:` attribute → entity instances.
+- Neither declared → associative arrays.
+- DML statement → `[]` (no fetch happens).
+
+`$rows === []` therefore means either "DML, didn't fetch" or "SELECT, no matches" — pick a result class scoped to one or the other rather than trying to handle both shapes.
+
+**Generic base for reuse across repositories:**
+
+Lift the entity out as a type variable when several repositories want the same shape with different entities. Psalm and PHPStan propagate the parameter through `foreach`, `$rows[N]`, and `iterator_to_array(...)`:
+
+```php
+/**
+ * @template T
+ * @implements IteratorAggregate<int, T>
+ */
+abstract class TypedRows implements PostQueryInterface, IteratorAggregate, Countable
+{
+    /** @param list<T> $rows */
+    public function __construct(public readonly array $rows) {}
+
+    public static function fromContext(PostQueryContext $context): static
+    {
+        /** @var list<T> $rows */
+        $rows = $context->rows;
+
+        return new static($rows);
+    }
+
+    /** @return ArrayIterator<int, T> */
+    public function getIterator(): ArrayIterator { return new ArrayIterator($this->rows); }
+    public function count(): int { return count($this->rows); }
+    public function isEmpty(): bool { return $this->rows === []; }
+}
+
+/** @extends TypedRows<Article> */
+final class Articles extends TypedRows
+{
+    public function published(): self { /* domain operations on Article rows */ }
+    public function totalWordCount(): int { /* ... */ }
+}
+
+/** @extends TypedRows<User> */
+final class Users extends TypedRows {}
+```
+
+`@extends TypedRows<Article>` carries `Article` through to every site that inspects the rows — `$articles->rows[0]->title`, `foreach ($articles as $a) { $a->wordCount; }`, and any derived method on the base. The framework still hands `$context->rows` as `array<mixed>`; the narrow happens at the `@var list<T>` line in `fromContext()`, and from that point on the static analyser honours the parameter. Runtime is identical to the single-type wrapper above — PHP has no native generics, so this is a static-analysis claim, not a runtime check.
+
 **Constructor Property Promotion (Recommended):**
 
 Use constructor property promotion for type-safe, immutable entities:
@@ -565,7 +671,7 @@ class CustomRepository
 - `getRow($queryId, $params)` - Single row
 - `getRowList($queryId, $params)` - Multiple rows
 - `exec($queryId, $params)` - Execute without result
-- `execPostQuery($queryId, $params, $postQueryClass)` - Execute DML and build a typed result via a `PostQueryInterface` class (e.g. `AffectedRows`, `InsertedRow`, or a custom class)
+- `execPostQuery($queryId, $params, $postQueryClass, $fetch = null)` - Execute a SQL statement (SELECT or DML) and build a typed result via a `PostQueryInterface` class (e.g. `AffectedRows`, `InsertedRow`, a typed collection wrapper, or any custom class)
 - `getCount($queryId, $params)` - Total row count (for pagination)
 - `getStatement()` - Get PDO statement
 - `getPages()` - Get paginated results

--- a/src/DbQueryInterceptor.php
+++ b/src/DbQueryInterceptor.php
@@ -53,7 +53,9 @@ final class DbQueryInterceptor implements MethodInterceptor
         if ($returnType instanceof ReflectionNamedType) {
             $typeName = $returnType->getName();
             if (class_exists($typeName) && is_subclass_of($typeName, PostQueryInterface::class)) {
-                return $this->sqlQuery->execPostQuery($dbQuery->id, $values, $typeName);
+                $postQueryFetch = $this->factory->factory($dbQuery, $entity, $returnType);
+
+                return $this->sqlQuery->execPostQuery($dbQuery->id, $values, $typeName, $postQueryFetch);
             }
         }
 

--- a/src/Result/PostQueryContext.php
+++ b/src/Result/PostQueryContext.php
@@ -8,21 +8,29 @@ use Aura\Sql\ExtendedPdoInterface;
 use PDOStatement;
 
 /**
- * Context passed to {@see PostQueryInterface::fromContext()} after DML execution.
+ * Context passed to {@see PostQueryInterface::fromContext()} after execution.
  *
  * Carries the executed statement, the connection, and the parameter values as
  * resolved by `ParamConverter` / `ParamInjector` — i.e. with injected defaults
  * (UUIDs, timestamps), `DateTime` converted to SQL strings, and `ToScalarInterface`
  * value objects reduced to scalars. These resolved values are what actually went
  * to the driver, and they are not otherwise observable by the caller.
+ *
+ * For SELECT paths, `$rows` holds the pre-hydrated result set (entity instances
+ * when an entity is configured, or associative arrays otherwise). For DML paths
+ * no fetch happens and `$rows` is `[]`.
  */
 final class PostQueryContext
 {
-    /** @param array<string, mixed> $values */
+    /**
+     * @param array<string, mixed> $values
+     * @param array<mixed>         $rows   Hydrated rows for SELECT; `[]` for DML.
+     */
     public function __construct(
         public readonly PDOStatement $statement,
         public readonly ExtendedPdoInterface $pdo,
         public readonly array $values,
+        public readonly array $rows = [],
     ) {
     }
 }

--- a/src/Result/PostQueryInterface.php
+++ b/src/Result/PostQueryInterface.php
@@ -5,14 +5,16 @@ declare(strict_types=1);
 namespace Ray\MediaQuery\Result;
 
 /**
- * Return-type contract for DML results built from post-execution PDO state.
+ * Return-type contract for results built after a query executes.
  *
  * Any class implementing this interface can be declared as the return type of
- * a `#[DbQuery]` method. The DbQueryInterceptor detects the interface via
- * `is_subclass_of` and calls the static {@see self::fromContext()} factory with
- * a {@see PostQueryContext} holding the executed statement, its connection,
- * and the resolved parameter values. Each result class owns the logic that
- * turns that context into its own shape.
+ * a `#[DbQuery]` method, for either a DML statement (e.g. {@see AffectedRows},
+ * {@see InsertedRow}) or a SELECT (a typed collection wrapping the hydrated
+ * rows). The DbQueryInterceptor detects the interface via `is_subclass_of` and
+ * calls the static {@see self::fromContext()} factory with a
+ * {@see PostQueryContext} holding the executed statement, its connection, the
+ * resolved parameter values, and — for SELECT — the hydrated rows. Each result
+ * class owns the logic that turns that context into its own shape.
  */
 interface PostQueryInterface
 {

--- a/src/ReturnEntity.php
+++ b/src/ReturnEntity.php
@@ -12,6 +12,7 @@ use phpDocumentor\Reflection\Type;
 use phpDocumentor\Reflection\Types\Array_;
 use phpDocumentor\Reflection\Types\ContextFactory;
 use phpDocumentor\Reflection\Types\Object_;
+use Ray\MediaQuery\Result\PostQueryInterface;
 use ReflectionMethod;
 use ReflectionNamedType;
 use ReflectionType;
@@ -40,7 +41,11 @@ final class ReturnEntity implements ReturnEntityInterface
 
         $returnTypeClass = $this->getReturnTypeName($returnType);
 
-        if (class_exists($returnTypeClass) && ! is_a($returnTypeClass, PagesInterface::class, true)) {
+        if (
+            class_exists($returnTypeClass)
+            && ! is_a($returnTypeClass, PagesInterface::class, true)
+            && ! is_a($returnTypeClass, PostQueryInterface::class, true)
+        ) {
             return $returnTypeClass;
         }
 

--- a/src/SqlQuery.php
+++ b/src/SqlQuery.php
@@ -107,12 +107,12 @@ final class SqlQuery implements SqlQueryInterface
      * @psalm-taint-escape sql
      */
     #[Override]
-    public function execPostQuery(string $sqlId, array $values, string $postQueryClass): PostQueryInterface
+    public function execPostQuery(string $sqlId, array $values, string $postQueryClass, FetchInterface|null $fetch = null): PostQueryInterface
     {
-        $this->perform($sqlId, $values, null);
+        $rows = $this->perform($sqlId, $values, $fetch);
         assert($this->pdoStatement instanceof PDOStatement);
 
-        $context = new PostQueryContext($this->pdoStatement, $this->pdo, $this->lastValues);
+        $context = new PostQueryContext($this->pdoStatement, $this->pdo, $this->lastValues, $rows);
 
         return $postQueryClass::fromContext($context);
     }

--- a/src/SqlQueryInterface.php
+++ b/src/SqlQueryInterface.php
@@ -15,10 +15,11 @@ use Ray\MediaQuery\Result\PostQueryInterface;
  *  - `get*`  — SELECT queries; execute and return the result set or a
  *              derivation of it ({@see self::getRow()}, {@see self::getRowList()},
  *              {@see self::getCount()}, {@see self::getPages()}).
- *  - `exec*` — DML queries (INSERT / UPDATE / DELETE); execute and either
- *              return nothing ({@see self::exec()}) or return a typed result
- *              built from the post-execution PDO state
- *              ({@see self::execPostQuery()}).
+ *  - `exec*` — execute and build a typed result. {@see self::exec()} runs a
+ *              DML statement without reading a result.
+ *              {@see self::execPostQuery()} dispatches through the user-defined
+ *              {@see PostQueryInterface} factory for either SELECT (hydrated
+ *              rows available on the context) or DML (post-execution PDO state).
  */
 interface SqlQueryInterface
 {
@@ -55,13 +56,17 @@ interface SqlQueryInterface
     public function exec(string $sqlId, array $values = [], FetchInterface|null $fetch = null): void;
 
     /**
-     * Execute a DML statement and build a result through the given PostQuery class.
+     * Execute a SQL statement and build a result through the given PostQuery class.
      *
      * The framework calls `{$postQueryClass}::fromContext($context)` after
      * executing the SQL. Each result class owns its own construction logic, so
      * the caller's return-type declaration is what selects behaviour (count only,
-     * count + last insert id, etc.). When the SQL file contains multiple
-     * statements, the result reflects the last executed statement only.
+     * count + last insert id, a typed collection wrapper, etc.). For SELECT
+     * statements the rows are pre-hydrated and exposed on the context's `$rows`
+     * property — entity instances when `$fetch` is provided, associative arrays
+     * otherwise. For DML statements no fetch happens and `$rows` is `[]`. When
+     * the SQL file contains multiple statements, the result reflects the last
+     * executed statement only.
      *
      * @param array<string, mixed> $values
      * @param class-string<T>      $postQueryClass
@@ -71,7 +76,7 @@ interface SqlQueryInterface
      * @template T of PostQueryInterface
      * @psalm-taint-escape sql
      */
-    public function execPostQuery(string $sqlId, array $values, string $postQueryClass): PostQueryInterface;
+    public function execPostQuery(string $sqlId, array $values, string $postQueryClass, FetchInterface|null $fetch = null): PostQueryInterface;
 
     /**
      * Return the total row count for a SELECT. Used as the pagination denominator.

--- a/src/SqlQueryInterface.php
+++ b/src/SqlQueryInterface.php
@@ -71,6 +71,8 @@ interface SqlQueryInterface
      *
      * @param array<string, mixed> $values
      * @param class-string<T>      $postQueryClass
+     * @param FetchInterface|null  $fetch          Strategy used to hydrate SELECT rows. Pass
+     *                                             null for DML or to receive associative arrays.
      *
      * @return T
      *

--- a/src/SqlQueryInterface.php
+++ b/src/SqlQueryInterface.php
@@ -62,11 +62,12 @@ interface SqlQueryInterface
      * executing the SQL. Each result class owns its own construction logic, so
      * the caller's return-type declaration is what selects behaviour (count only,
      * count + last insert id, a typed collection wrapper, etc.). For SELECT
-     * statements the rows are pre-hydrated and exposed on the context's `$rows`
-     * property — entity instances when `$fetch` is provided, associative arrays
-     * otherwise. For DML statements no fetch happens and `$rows` is `[]`. When
-     * the SQL file contains multiple statements, the result reflects the last
-     * executed statement only.
+     * statements the rows are fetched and exposed on the context's `$rows`
+     * property — shape is determined by the supplied `$fetch` strategy (entity
+     * instances for an entity-bound fetch, associative arrays for `FetchAssoc`),
+     * or associative arrays when `$fetch` is null. For DML statements no fetch
+     * happens and `$rows` is `[]`. When the SQL file contains multiple
+     * statements, the result reflects the last executed statement only.
      *
      * @param array<string, mixed> $values
      * @param class-string<T>      $postQueryClass

--- a/tests/DbQuerySelectPostQueryTest.php
+++ b/tests/DbQuerySelectPostQueryTest.php
@@ -9,13 +9,12 @@ use PDO;
 use PHPUnit\Framework\TestCase;
 use Ray\AuraSqlModule\AuraSqlModule;
 use Ray\Di\Injector;
-use Ray\MediaQuery\Entity\Article;
 use Ray\MediaQuery\Queries\ArticlesInterface;
 use Ray\MediaQuery\Result\Articles;
 
 use function dirname;
 use function file_get_contents;
-use function usort;
+use function iterator_to_array;
 
 class DbQuerySelectPostQueryTest extends TestCase
 {
@@ -46,15 +45,12 @@ class DbQuerySelectPostQueryTest extends TestCase
         $result = $repo->listAssoc();
 
         $this->assertInstanceOf(Articles::class, $result);
-        /** @var list<array{id: string, title: string}> $rows */
-        $rows = $result->rows;
-        usort($rows, static fn (array $a, array $b): int => $a['id'] <=> $b['id']);
         $this->assertSame(
             [
                 ['id' => '1', 'title' => 'run'],
                 ['id' => '2', 'title' => 'walk'],
             ],
-            $rows,
+            $result->rows,
         );
     }
 
@@ -66,14 +62,54 @@ class DbQuerySelectPostQueryTest extends TestCase
         $this->assertInstanceOf(Articles::class, $result);
         $this->assertCount(2, $result->rows);
 
-        /** @var list<Article> $rows */
         $rows = $result->rows;
-        usort($rows, static fn (Article $a, Article $b): int => $a->id <=> $b->id);
 
+        // The `@return Articles<Article>` declaration carries `Article` through to
+        // `$rows[0]`, so `->id` / `->title` are statically typed without a cast.
         $this->assertSame('1', $rows[0]->id);
         $this->assertSame('run', $rows[0]->title);
-
         $this->assertSame('2', $rows[1]->id);
         $this->assertSame('walk', $rows[1]->title);
+    }
+
+    public function testWrapperExposesCountableAndIteratorAggregate(): void
+    {
+        $repo = $this->injector->getInstance(ArticlesInterface::class);
+        $result = $repo->listHydrated();
+
+        $this->assertCount(2, $result);
+        $this->assertFalse($result->isEmpty());
+
+        // `iterator_to_array(Articles<Article>)` yields `array<int, Article>`.
+        $iterated = iterator_to_array($result, false);
+        $this->assertSame($result->rows, $iterated);
+    }
+
+    public function testFactoryAttributeHydratesViaPostQueryPath(): void
+    {
+        $repo = $this->injector->getInstance(ArticlesInterface::class);
+        $result = $repo->listViaFactory();
+
+        $this->assertInstanceOf(Articles::class, $result);
+        $this->assertCount(2, $result->rows);
+
+        $rows = $result->rows;
+
+        // `@return Articles<TodoConstruct>` carries through here too.
+        $this->assertSame('1', $rows[0]->id);
+        $this->assertSame('run', $rows[0]->title);
+        $this->assertSame('2', $rows[1]->id);
+        $this->assertSame('walk', $rows[1]->title);
+    }
+
+    public function testEmptySelectStillReturnsArticlesWrapper(): void
+    {
+        $repo = $this->injector->getInstance(ArticlesInterface::class);
+        $result = $repo->listEmpty();
+
+        $this->assertInstanceOf(Articles::class, $result);
+        $this->assertSame([], $result->rows);
+        $this->assertCount(0, $result);
+        $this->assertTrue($result->isEmpty());
     }
 }

--- a/tests/DbQuerySelectPostQueryTest.php
+++ b/tests/DbQuerySelectPostQueryTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+
+use Aura\Sql\ExtendedPdoInterface;
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Ray\AuraSqlModule\AuraSqlModule;
+use Ray\Di\Injector;
+use Ray\MediaQuery\Entity\Article;
+use Ray\MediaQuery\Queries\ArticlesInterface;
+use Ray\MediaQuery\Result\Articles;
+
+use function dirname;
+use function file_get_contents;
+
+class DbQuerySelectPostQueryTest extends TestCase
+{
+    private Injector $injector;
+
+    protected function setUp(): void
+    {
+        $mediaQueries = Queries::fromClasses([
+            ArticlesInterface::class,
+        ]);
+        $sqlDir = dirname(__DIR__) . '/tests/sql';
+        $dbQueryConfig = new DbQueryConfig($sqlDir);
+        $module = new MediaQueryModule(
+            $mediaQueries,
+            [$dbQueryConfig],
+            new AuraSqlModule('sqlite::memory:', '', '', '', [PDO::ATTR_STRINGIFY_FETCHES => true]), // @phpstan-ignore-line
+        );
+        $this->injector = new Injector($module, __DIR__ . '/tmp');
+        $pdo = $this->injector->getInstance(ExtendedPdoInterface::class);
+        $pdo->query((string) file_get_contents($sqlDir . '/create_todo.sql'));
+        $pdo->perform((string) file_get_contents($sqlDir . '/todo_add.sql'), ['id' => '1', 'title' => 'run']);
+        $pdo->perform((string) file_get_contents($sqlDir . '/todo_add.sql'), ['id' => '2', 'title' => 'walk']);
+    }
+
+    public function testReturnsArticlesWrapperWithAssocRows(): void
+    {
+        $repo = $this->injector->getInstance(ArticlesInterface::class);
+        $result = $repo->listAssoc();
+
+        $this->assertInstanceOf(Articles::class, $result);
+        $this->assertSame(
+            [
+                ['id' => '1', 'title' => 'run'],
+                ['id' => '2', 'title' => 'walk'],
+            ],
+            $result->rows,
+        );
+    }
+
+    public function testReturnsArticlesWrapperWithHydratedEntities(): void
+    {
+        $repo = $this->injector->getInstance(ArticlesInterface::class);
+        $result = $repo->listHydrated();
+
+        $this->assertInstanceOf(Articles::class, $result);
+        $this->assertCount(2, $result->rows);
+
+        [$first, $second] = [$result->rows[0], $result->rows[1]];
+
+        $this->assertInstanceOf(Article::class, $first);
+        $this->assertSame('1', $first->id);
+        $this->assertSame('run', $first->title);
+
+        $this->assertInstanceOf(Article::class, $second);
+        $this->assertSame('2', $second->id);
+        $this->assertSame('walk', $second->title);
+    }
+}

--- a/tests/DbQuerySelectPostQueryTest.php
+++ b/tests/DbQuerySelectPostQueryTest.php
@@ -15,6 +15,7 @@ use Ray\MediaQuery\Result\Articles;
 
 use function dirname;
 use function file_get_contents;
+use function usort;
 
 class DbQuerySelectPostQueryTest extends TestCase
 {
@@ -45,12 +46,15 @@ class DbQuerySelectPostQueryTest extends TestCase
         $result = $repo->listAssoc();
 
         $this->assertInstanceOf(Articles::class, $result);
+        /** @var list<array{id: string, title: string}> $rows */
+        $rows = $result->rows;
+        usort($rows, static fn (array $a, array $b): int => $a['id'] <=> $b['id']);
         $this->assertSame(
             [
                 ['id' => '1', 'title' => 'run'],
                 ['id' => '2', 'title' => 'walk'],
             ],
-            $result->rows,
+            $rows,
         );
     }
 
@@ -62,14 +66,14 @@ class DbQuerySelectPostQueryTest extends TestCase
         $this->assertInstanceOf(Articles::class, $result);
         $this->assertCount(2, $result->rows);
 
-        [$first, $second] = [$result->rows[0], $result->rows[1]];
+        /** @var list<Article> $rows */
+        $rows = $result->rows;
+        usort($rows, static fn (Article $a, Article $b): int => $a->id <=> $b->id);
 
-        $this->assertInstanceOf(Article::class, $first);
-        $this->assertSame('1', $first->id);
-        $this->assertSame('run', $first->title);
+        $this->assertSame('1', $rows[0]->id);
+        $this->assertSame('run', $rows[0]->title);
 
-        $this->assertInstanceOf(Article::class, $second);
-        $this->assertSame('2', $second->id);
-        $this->assertSame('walk', $second->title);
+        $this->assertSame('2', $rows[1]->id);
+        $this->assertSame('walk', $rows[1]->title);
     }
 }

--- a/tests/Fake/Entity/Article.php
+++ b/tests/Fake/Entity/Article.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery\Entity;
+
+class Article
+{
+    /** @var string */
+    public $id;
+
+    /** @var string */
+    public $title;
+}

--- a/tests/Fake/FakeSqlQuery.php
+++ b/tests/Fake/FakeSqlQuery.php
@@ -46,7 +46,7 @@ final class FakeSqlQuery implements SqlQueryInterface
      *
      * @param array<string, mixed> $values
      */
-    public function execPostQuery(string $sqlId, array $values, string $postQueryClass): PostQueryInterface
+    public function execPostQuery(string $sqlId, array $values, string $postQueryClass, FetchInterface|null $fetch = null): PostQueryInterface
     {
         throw new LogicException('FakeSqlQuery does not support execPostQuery');
     }

--- a/tests/Fake/Queries/ArticlesInterface.php
+++ b/tests/Fake/Queries/ArticlesInterface.php
@@ -6,14 +6,18 @@ namespace Ray\MediaQuery\Queries;
 
 use Ray\MediaQuery\Annotation\DbQuery;
 use Ray\MediaQuery\Entity\Article;
+use Ray\MediaQuery\Entity\TodoConstruct;
+use Ray\MediaQuery\Factory\TodoEntityFactory;
 use Ray\MediaQuery\Result\Articles;
 
 interface ArticlesInterface
 {
     /**
      * Rows come back as associative arrays (no entity hydration).
+     *
+     * @return Articles<array<string, mixed>>
      */
-    #[DbQuery('todo_list')]
+    #[DbQuery('article_list')]
     public function listAssoc(): Articles;
 
     /**
@@ -21,6 +25,23 @@ interface ArticlesInterface
      *
      * @return Articles<Article>
      */
-    #[DbQuery('todo_list')]
+    #[DbQuery('article_list')]
     public function listHydrated(): Articles;
+
+    /**
+     * Rows come back as `TodoConstruct` instances via the `factory:` attribute.
+     *
+     * @return Articles<TodoConstruct>
+     */
+    #[DbQuery('article_list', factory: TodoEntityFactory::class)]
+    public function listViaFactory(): Articles;
+
+    /**
+     * SELECT that matches no rows — `$rows` is `[]`, but the wrapper is still
+     * an `Articles`, not null.
+     *
+     * @return Articles<array<string, mixed>>
+     */
+    #[DbQuery('article_list_empty')]
+    public function listEmpty(): Articles;
 }

--- a/tests/Fake/Queries/ArticlesInterface.php
+++ b/tests/Fake/Queries/ArticlesInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery\Queries;
+
+use Ray\MediaQuery\Annotation\DbQuery;
+use Ray\MediaQuery\Entity\Article;
+use Ray\MediaQuery\Result\Articles;
+
+interface ArticlesInterface
+{
+    /**
+     * Rows come back as associative arrays (no entity hydration).
+     */
+    #[DbQuery('todo_list')]
+    public function listAssoc(): Articles;
+
+    /**
+     * Rows come back as `Article` instances via docblock-driven entity hydration.
+     *
+     * @return Articles<Article>
+     */
+    #[DbQuery('todo_list')]
+    public function listHydrated(): Articles;
+}

--- a/tests/Fake/Result/Articles.php
+++ b/tests/Fake/Result/Articles.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery\Result;
+
+use Override;
+
+/**
+ * SELECT-path PostQuery result: wraps the hydrated rows as a typed collection.
+ *
+ * Callers that declare `Articles` as their return type receive the rows via
+ * `$context->rows`, pre-hydrated by the framework (entity instances when an
+ * entity is configured, associative arrays otherwise).
+ */
+final class Articles implements PostQueryInterface
+{
+    /** @param array<mixed> $rows */
+    public function __construct(
+        public readonly array $rows,
+    ) {
+    }
+
+    #[Override]
+    public static function fromContext(PostQueryContext $context): static
+    {
+        return new static($context->rows);
+    }
+}

--- a/tests/Fake/Result/Articles.php
+++ b/tests/Fake/Result/Articles.php
@@ -4,18 +4,33 @@ declare(strict_types=1);
 
 namespace Ray\MediaQuery\Result;
 
+use ArrayIterator;
+use Countable;
+use IteratorAggregate;
 use Override;
 
+use function count;
+
 /**
- * SELECT-path PostQuery result: wraps the hydrated rows as a typed collection.
+ * Test fake — not part of the public API.
  *
- * Callers that declare `Articles` as their return type receive the rows via
- * `$context->rows`, pre-hydrated by the framework (entity instances when an
- * entity is configured, associative arrays otherwise).
+ * SELECT-path PostQuery result: a typed collection wrapper around the rows
+ * pre-hydrated by the framework.
+ *
+ * The generic parameter `T` is the row shape — typically an entity class
+ * (`Articles<Article>`) when `@return Articles<EntityClass>` or a `factory:`
+ * attribute resolves to one, or `array<string, mixed>` for the assoc-array
+ * fallback. The framework still hands `$context->rows` as `array<mixed>`;
+ * the wrapper narrows it to `list<T>` based on the caller's declaration. PHP
+ * has no runtime generics, so the narrow is a docblock claim — Psalm and
+ * PHPStan honour it through to `foreach`, `->rows[0]`, and derived methods.
+ *
+ * @template T
+ * @implements IteratorAggregate<int, T>
  */
-final class Articles implements PostQueryInterface
+final class Articles implements PostQueryInterface, IteratorAggregate, Countable
 {
-    /** @param array<mixed> $rows */
+    /** @param list<T> $rows */
     public function __construct(
         public readonly array $rows,
     ) {
@@ -24,6 +39,27 @@ final class Articles implements PostQueryInterface
     #[Override]
     public static function fromContext(PostQueryContext $context): static
     {
-        return new static($context->rows);
+        /** @var list<T> $rows */
+        $rows = $context->rows;
+
+        return new static($rows);
+    }
+
+    /** @return ArrayIterator<int, T> */
+    #[Override]
+    public function getIterator(): ArrayIterator
+    {
+        return new ArrayIterator($this->rows);
+    }
+
+    #[Override]
+    public function count(): int
+    {
+        return count($this->rows);
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->rows === [];
     }
 }

--- a/tests/sql/article_list.sql
+++ b/tests/sql/article_list.sql
@@ -1,0 +1,3 @@
+SELECT id, title
+  FROM todo
+ ORDER BY id

--- a/tests/sql/article_list_empty.sql
+++ b/tests/sql/article_list_empty.sql
@@ -1,0 +1,3 @@
+SELECT id, title
+  FROM todo
+ WHERE 1 = 0


### PR DESCRIPTION
Implements the unified design from #88 and supersedes #87 (closed).

## What changed

SELECT return types can now implement `PostQueryInterface` just like DML results. The framework pre-hydrates the row list into `PostQueryContext::$rows`; the factory wraps them in a typed collection that carries **domain operations on the result set as a whole** — which is what a raw `array<Article>` can't express.

```php
use Ray\MediaQuery\Result\PostQueryContext;
use Ray\MediaQuery\Result\PostQueryInterface;

/** @implements IteratorAggregate<int, Article> */
final class Articles implements PostQueryInterface, IteratorAggregate, Countable
{
    /** @param list<Article> $rows */
    public function __construct(public readonly array $rows) {}

    public static function fromContext(PostQueryContext $context): static
    {
        /** @var list<Article> $rows */
        $rows = $context->rows;

        return new static($rows);
    }

    /** Domain predicates / aggregations — the reason to wrap. */
    public function published(): self
    {
        return new self(array_values(array_filter(
            $this->rows,
            static fn (Article $a): bool => $a->isPublished(),
        )));
    }

    public function totalWordCount(): int
    {
        return array_sum(array_map(
            static fn (Article $a): int => $a->wordCount,
            $this->rows,
        ));
    }

    public function getIterator(): ArrayIterator { return new ArrayIterator($this->rows); }
    public function count(): int { return count($this->rows); }
}

interface ArticleRepository
{
    #[DbQuery('article_list')]
    /** @return Articles<Article> */
    public function list(): Articles;
}
```

Callers get `$articles->published()->totalWordCount()` — domain logic about the collection lives on the type, not scattered across services. `IteratorAggregate` / `Countable` just give the wrapper the normal "feels like an array" ergonomics on top. Wrapping a Laravel / Illuminate / Doctrine Collection via a property is the same pattern when you want a richer base.

## Why this replaces #87

#87 auto-detected `Traversable` + instantiable + constructor-param-count via reflection and invoked `new ReflectionClass(...)->newInstanceArgs([$rows])`. The new approach:

- **One dispatch path** — `DbQueryInterceptor` already had the `is_subclass_of(..., PostQueryInterface::class)` branch for DML. SELECT now rides on the same check. No separate detector class, no magic constructor invocation.
- **Composition over inheritance** — users wrap rows via a property rather than extending a Collection base class. Works with any Collection library, and the wrapper can carry adjacent metadata.
- **Opt-in, explicit** — `implements PostQueryInterface` + a small factory is the boilerplate cost. In exchange: type-safe `static` returns, alignment with the DML path, and no reflection-based magic.
- **Entity hydration stays in the existing pipeline** — `FetchInterface` / `FetchFactory` / `Injector` produce `array<Article>`, the framework hands it to the factory via `$context->rows`. The wrapper never touches raw rows or DI.

See #88 for the design memo and the rationale in full.

## Implementation

- **`src/Result/PostQueryContext.php`** — adds `public readonly array $rows = []`. Hydrated for SELECT, empty for DML.
- **`src/SqlQueryInterface.php` / `src/SqlQuery.php`** — `execPostQuery` gains `FetchInterface|null $fetch = null`. `SqlQuery` passes `$fetch` through `perform()` (already SELECT/DML-aware) and populates `PostQueryContext::$rows` with the returned rows.
- **`src/DbQueryInterceptor.php`** — builds a `FetchInterface` via the existing `FetchFactory` and forwards it to `execPostQuery` for `PostQueryInterface` return types. No new branches.
- **`src/ReturnEntity.php`** — treats `PostQueryInterface` implementations the same as `PagesInterface`: skip the class-name return so a docblock like `@return Articles<Article>` resolves to `Article` via the existing generic-extraction path.

## Follow-up commit ([fa84611](https://github.com/ray-di/Ray.MediaQuery/commit/fa84611))

Tightens documentation, tests, and generic typing without changing the production surface beyond docblocks:

- **Docs catch up with semantics** — `PostQueryInterface`, `SqlQueryInterface`, and the README now reflect the unified SELECT + DML coverage. The original "DML results" wording was stale after this PR routed SELECT through the same path. Addresses Copilot review (missing `@param FetchInterface|null $fetch`).
- **README gains a SELECT example** — a single-type `Articles` wrapper showing `published()` / `totalWordCount()` / `IteratorAggregate` / `Countable`, plus shape rules for `$rows` and the meaning of `$rows === []`.
- **README gains a generic example** — a `TypedRows<T>` base class with `extends TypedRows<Article>` / `extends TypedRows<User>` for sharing a wrapper across entity types. The narrow happens at the `@var list<T>` line in `fromContext()`; from there Psalm and PHPStan honour the parameter through `foreach`, `$rows[N]`, `iterator_to_array(...)`, and any derived method.
- **Test fixtures decouple from `todo_list.sql`** — new `article_list.sql` (with `ORDER BY id`) and `article_list_empty.sql` so the Articles tests no longer share fixtures with the rest of the suite.
- **Articles fake gains `IteratorAggregate`, `Countable`, `isEmpty`, and `@template T`** — its `@return Articles<Entity>` propagation is verified end-to-end. As a positive side-effect, six runtime type checks (`assertContainsOnlyInstancesOf` × 2, `assertInstanceOf` × 4) fall away because the docblock carries the narrow.
- **Three new tests** — `factory:` attribute combined with `PostQueryInterface`, empty SELECT, and the `Countable` / `IteratorAggregate` ergonomics.

## Test plan

- [x] `composer test` — 101 tests, 176 assertions (was 98 before fa84611; +3 new tests, runtime instance assertions removed where the docblock narrow makes them redundant)
- [x] `composer cs` — clean
- [x] `./vendor-bin/tools/vendor/bin/phpstan --memory-limit=1G` — no errors (level max)
- [x] `./vendor-bin/tools/vendor/bin/psalm --no-cache` — no errors (error level 1)
- [x] `DbQuerySelectPostQueryTest` covers:
  - `Articles` wrapper returned from a SELECT
  - `$context->rows` as hydrated `Article` instances when `@return Articles<Article>` is declared
  - `$context->rows` as `TodoConstruct` instances when `factory: TodoEntityFactory::class` is supplied
  - `$context->rows` as raw assoc arrays when no entity type is declared
  - Empty SELECT returns an `Articles` wrapper with `$rows === []`, `count() === 0`, `isEmpty() === true`
  - `iterator_to_array($articles)` matches `$articles->rows`
- [x] Existing DML paths (`AffectedRows`, `InsertedRow`, `DbQueryCustomPostQueryTest::RowCountWithQuery`) still work — their `$rows` stays `[]`, other fields unchanged

Refs #88 (design memo), #87 (closed, superseded).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SELECT queries now return typed result wrappers containing accessible rows instead of raw statements.
  * Results support multiple fetch strategies: associative arrays, hydrated entity instances, or factory-based construction.
  * Result wrappers are iterable and countable for convenient row access and inspection.

* **Tests**
  * Added comprehensive test coverage for SELECT query result wrapping, hydration, and iteration behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->