### PR TITLE
Honor DbQuery factory in pager hydration

### DIFF
--- a/src/DbPager.php
+++ b/src/DbPager.php
@@ -42,8 +42,14 @@ final class DbPager
             return $result;
         }
 
+        if ($result instanceof Pages) {
+            $result->setRowMapper($rowMapper);
+
+            return $result;
+        }
+
         // Keep the wrapper fallback for custom SqlQueryInterface implementations that do not return Pages.
-        return $result instanceof Pages ? $result->withRowMapper($rowMapper) : new MappedPages($result, $rowMapper);
+        return new MappedPages($result, $rowMapper);
     }
 
     /**

--- a/src/DbPager.php
+++ b/src/DbPager.php
@@ -42,6 +42,7 @@ final class DbPager
             return $result;
         }
 
+        // Keep the wrapper fallback for custom SqlQueryInterface implementations that do not return Pages.
         return $result instanceof Pages ? $result->withRowMapper($rowMapper) : new MappedPages($result, $rowMapper);
     }
 

--- a/src/DbPager.php
+++ b/src/DbPager.php
@@ -20,8 +20,11 @@ final class DbPager
     ) {
     }
 
-    /** @param array<string, mixed> $values */
-    public function __invoke(string $queryId, array $values, Pager $pager, string|null $entity): PagesInterface
+    /**
+     * @param array<string, mixed>                            $values
+     * @param (callable(array<array-key, mixed>): mixed)|null $rowMapper
+     */
+    public function __invoke(string $queryId, array $values, Pager $pager, string|null $entity, callable|null $rowMapper = null): PagesInterface
     {
         // Clone the Pager attribute to avoid mutating the caller's instance in dynamicPager().
         $pager = clone $pager;
@@ -32,10 +35,14 @@ final class DbPager
         assert(is_int($pager->perPage));
         $this->logger->start();
         /** @var ?class-string $entity */
-        $result = $this->sqlQuery->getPages($queryId, $values, $pager->perPage, $pager->template, $entity);
+        $result = $this->sqlQuery->getPages($queryId, $values, $pager->perPage, $pager->template, $rowMapper === null ? $entity : null);
         $this->logger->log($queryId, $values);
 
-        return $result;
+        if ($rowMapper === null) {
+            return $result;
+        }
+
+        return $result instanceof Pages ? $result->withRowMapper($rowMapper) : new MappedPages($result, $rowMapper);
     }
 
     /**

--- a/src/DbQueryInterceptor.php
+++ b/src/DbQueryInterceptor.php
@@ -27,6 +27,7 @@ final class DbQueryInterceptor implements MethodInterceptor
         private ParamInjectorInterface $paramInjector,
         private ReturnEntityInterface $returnEntity,
         private FetchFactoryInterface $factory,
+        private PageRowMapperFactory $pageRowMapperFactory,
         #[Set(DbPager::class)]
         private ProviderInterface $dbPagerProvider,
     ) {
@@ -45,7 +46,7 @@ final class DbQueryInterceptor implements MethodInterceptor
         if ($pager instanceof Pager) {
             $dbPager = $this->dbPagerProvider->get();
 
-            return ($dbPager)($dbQuery->id, $values, $pager, $entity);
+            return ($dbPager)($dbQuery->id, $values, $pager, $entity, $this->pageRowMapperFactory->create($dbQuery));
         }
 
         $returnType = $invocation->getMethod()->getReturnType();

--- a/src/FetchFactory.php
+++ b/src/FetchFactory.php
@@ -29,6 +29,7 @@ final class FetchFactory implements FetchFactoryInterface
     {
         unset($returnType);
 
+        // Keep factory dispatch semantics aligned with PageRowMapperFactory.
         $maybeFactory = [$dbQuery->factory, $this->factoryMehtod];
         if (is_callable($maybeFactory)) {
             // PDO::FETCH_FUNC with static factory method

--- a/src/MappedPages.php
+++ b/src/MappedPages.php
@@ -7,7 +7,6 @@ namespace Ray\MediaQuery;
 use Override;
 use Ray\AuraSqlModule\Pagerfanta\Page;
 
-use function array_map;
 use function is_array;
 
 final class MappedPages implements PagesInterface
@@ -33,17 +32,14 @@ final class MappedPages implements PagesInterface
     public function offsetGet(mixed $pageIndex): mixed
     {
         $page = $this->pages->offsetGet($pageIndex);
-        if (! $page instanceof Page || ! is_array($page->data)) {
+        $data = $page instanceof Page ? $page->data : null;
+        if (! $page instanceof Page || ! is_array($data)) {
             return $page;
         }
 
         $rowMapper = $this->rowMapper;
-        $page->data = array_map(
-            static function (mixed $row) use ($rowMapper): mixed {
-                return is_array($row) ? $rowMapper($row) : $row;
-            },
-            $page->data,
-        );
+        $page = clone $page;
+        $page->data = PageRows::map($data, $rowMapper);
 
         return $page;
     }

--- a/src/MappedPages.php
+++ b/src/MappedPages.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+
+use Override;
+use Ray\AuraSqlModule\Pagerfanta\Page;
+
+use function array_map;
+use function is_array;
+
+final class MappedPages implements PagesInterface
+{
+    /** @var callable(array<array-key, mixed>): mixed */
+    private $rowMapper;
+
+    /** @param callable(array<array-key, mixed>): mixed $rowMapper */
+    public function __construct(
+        private PagesInterface $pages,
+        callable $rowMapper,
+    ) {
+        $this->rowMapper = $rowMapper;
+    }
+
+    #[Override]
+    public function offsetExists(mixed $pageIndex): bool
+    {
+        return (bool) $this->offsetGet($pageIndex);
+    }
+
+    #[Override]
+    public function offsetGet(mixed $pageIndex): mixed
+    {
+        $page = $this->pages->offsetGet($pageIndex);
+        if (! $page instanceof Page || ! is_array($page->data)) {
+            return $page;
+        }
+
+        $rowMapper = $this->rowMapper;
+        $page->data = array_map(
+            static function (mixed $row) use ($rowMapper): mixed {
+                return is_array($row) ? $rowMapper($row) : $row;
+            },
+            $page->data,
+        );
+
+        return $page;
+    }
+
+    #[Override]
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->pages->offsetSet($offset, $value);
+    }
+
+    #[Override]
+    public function offsetUnset(mixed $offset): void
+    {
+        $this->pages->offsetUnset($offset);
+    }
+
+    #[Override]
+    public function count(): int
+    {
+        return $this->pages->count();
+    }
+}

--- a/src/MappedPages.php
+++ b/src/MappedPages.php
@@ -25,7 +25,7 @@ final class MappedPages implements PagesInterface
     #[Override]
     public function offsetExists(mixed $pageIndex): bool
     {
-        return (bool) $this->offsetGet($pageIndex);
+        return $this->pages->offsetExists($pageIndex);
     }
 
     #[Override]

--- a/src/MediaQueryDbModule.php
+++ b/src/MediaQueryDbModule.php
@@ -43,6 +43,7 @@ final class MediaQueryDbModule extends AbstractModule
         $this->bind(DocBlockFactoryInterface::class)->toInstance(DocBlockFactory::createInstance());
         $this->bind(ReturnEntityInterface::class)->to(ReturnEntity::class);
         $this->bind(FetchFactoryInterface::class)->to(FetchFactory::class);
+        $this->bind(PageRowMapperFactory::class);
         $this->bind()->annotatedWith(FactoryMethod::class)->toInstance('factory');
         $this->bind(DbPager::class);
     }

--- a/src/PageRowMapperFactory.php
+++ b/src/PageRowMapperFactory.php
@@ -25,6 +25,7 @@ final class PageRowMapperFactory
     /** @return (callable(array<array-key, mixed>): mixed)|null */
     public function create(DbQuery $dbQuery): callable|null
     {
+        // Keep factory dispatch semantics aligned with FetchFactory.
         $maybeFactory = [$dbQuery->factory, $this->factoryMethod];
         if (is_callable($maybeFactory)) {
             return static function (array $row) use ($maybeFactory): mixed {

--- a/src/PageRowMapperFactory.php
+++ b/src/PageRowMapperFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+
+use Ray\Di\InjectorInterface;
+use Ray\MediaQuery\Annotation\DbQuery;
+use Ray\MediaQuery\Annotation\Qualifier\FactoryMethod;
+
+use function array_values;
+use function class_exists;
+use function is_callable;
+use function method_exists;
+
+final class PageRowMapperFactory
+{
+    public function __construct(
+        #[FactoryMethod]
+        private string $factoryMethod,
+        private InjectorInterface $injector,
+    ) {
+    }
+
+    /** @return (callable(array<array-key, mixed>): mixed)|null */
+    public function create(DbQuery $dbQuery): callable|null
+    {
+        $maybeFactory = [$dbQuery->factory, $this->factoryMethod];
+        if (is_callable($maybeFactory)) {
+            return static function (array $row) use ($maybeFactory): mixed {
+                return $maybeFactory(...array_values($row));
+            };
+        }
+
+        if (! class_exists($dbQuery->factory) || ! method_exists($dbQuery->factory, $this->factoryMethod)) {
+            return null;
+        }
+
+        $factoryClass = $dbQuery->factory;
+        $factoryMethod = $this->factoryMethod;
+        $factory = $this->injector->getInstance($factoryClass);
+
+        return static function (array $row) use ($factory, $factoryMethod): mixed {
+            /** @psalm-suppress MixedMethodCall */
+            return $factory->$factoryMethod(...array_values($row));
+        };
+    }
+}

--- a/src/PageRowMapperFactory.php
+++ b/src/PageRowMapperFactory.php
@@ -39,9 +39,13 @@ final class PageRowMapperFactory
 
         $factoryClass = $dbQuery->factory;
         $factoryMethod = $this->factoryMethod;
-        $factory = $this->injector->getInstance($factoryClass);
+        $injector = $this->injector;
+        /** @var object|null $factory */
+        $factory = null;
 
-        return static function (array $row) use ($factory, $factoryMethod): mixed {
+        return static function (array $row) use ($injector, $factoryClass, $factoryMethod, &$factory): mixed {
+            $factory ??= $injector->getInstance($factoryClass);
+
             /** @psalm-suppress MixedMethodCall */
             return $factory->$factoryMethod(...array_values($row));
         };

--- a/src/PageRows.php
+++ b/src/PageRows.php
@@ -9,6 +9,11 @@ use function is_array;
 
 final class PageRows
 {
+    /** @codeCoverageIgnore */
+    private function __construct()
+    {
+    }
+
     /**
      * @param array<array-key, mixed>                  $rows
      * @param callable(array<array-key, mixed>): mixed $rowMapper

--- a/src/PageRows.php
+++ b/src/PageRows.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+
+use function array_map;
+use function is_array;
+
+final class PageRows
+{
+    /**
+     * @param array<array-key, mixed>                  $rows
+     * @param callable(array<array-key, mixed>): mixed $rowMapper
+     *
+     * @return array<array-key, mixed>
+     */
+    public static function map(array $rows, callable $rowMapper): array
+    {
+        return array_map(
+            static function (mixed $row) use ($rowMapper): mixed {
+                return is_array($row) ? $rowMapper($row) : $row;
+            },
+            $rows,
+        );
+    }
+}

--- a/src/Pages.php
+++ b/src/Pages.php
@@ -11,16 +11,39 @@ use Ray\AuraSqlModule\Pagerfanta\ExtendedPdoAdapter;
 use Ray\AuraSqlModule\Pagerfanta\Page;
 use Ray\MediaQuery\Exception\LogicException;
 
+use function array_map;
+use function is_array;
+
 /** @template T of class-string|mixed */
 final class Pages implements PagesInterface
 {
-    /** @param array<string, mixed> $params */
+    /** @var (callable(array<array-key, mixed>): mixed)|null */
+    private $rowMapper;
+
+    /**
+     * @param array<string, mixed>                            $params
+     * @param (callable(array<array-key, mixed>): mixed)|null $rowMapper
+     */
     public function __construct(
         private AuraSqlPagerInterface $delegate,
         private ExtendedPdoInterface $pdo,
         private string $sql,
         private array $params,
+        callable|null $rowMapper = null,
     ) {
+        $this->rowMapper = $rowMapper;
+    }
+
+    /**
+     * @param callable(array<array-key, mixed>): mixed $rowMapper
+     *
+     * @return self<T>
+     */
+    public function withRowMapper(callable $rowMapper): self
+    {
+        $this->rowMapper = $rowMapper;
+
+        return $this;
     }
 
     #[Override]
@@ -32,7 +55,20 @@ final class Pages implements PagesInterface
     #[Override]
     public function offsetGet($pageIndex): Page|null
     {
-        return $this->delegate->offsetGet($pageIndex);
+        $page = $this->delegate->offsetGet($pageIndex);
+        if (! $page instanceof Page || $this->rowMapper === null || ! is_array($page->data)) {
+            return $page;
+        }
+
+        $rowMapper = $this->rowMapper;
+        $page->data = array_map(
+            static function (mixed $row) use ($rowMapper): mixed {
+                return is_array($row) ? $rowMapper($row) : $row;
+            },
+            $page->data,
+        );
+
+        return $page;
     }
 
     /**

--- a/src/Pages.php
+++ b/src/Pages.php
@@ -11,7 +11,6 @@ use Ray\AuraSqlModule\Pagerfanta\ExtendedPdoAdapter;
 use Ray\AuraSqlModule\Pagerfanta\Page;
 use Ray\MediaQuery\Exception\LogicException;
 
-use function array_map;
 use function is_array;
 
 /** @template T of class-string|mixed */
@@ -56,17 +55,14 @@ final class Pages implements PagesInterface
     public function offsetGet($pageIndex): Page|null
     {
         $page = $this->delegate->offsetGet($pageIndex);
-        if (! $page instanceof Page || $this->rowMapper === null || ! is_array($page->data)) {
+        $data = $page instanceof Page ? $page->data : null;
+        if (! $page instanceof Page || $this->rowMapper === null || ! is_array($data)) {
             return $page;
         }
 
         $rowMapper = $this->rowMapper;
-        $page->data = array_map(
-            static function (mixed $row) use ($rowMapper): mixed {
-                return is_array($row) ? $rowMapper($row) : $row;
-            },
-            $page->data,
-        );
+        $page = clone $page;
+        $page->data = PageRows::map($data, $rowMapper);
 
         return $page;
     }

--- a/src/Pages.php
+++ b/src/Pages.php
@@ -33,21 +33,16 @@ final class Pages implements PagesInterface
         $this->rowMapper = $rowMapper;
     }
 
-    /**
-     * @param callable(array<array-key, mixed>): mixed $rowMapper
-     *
-     * @return self<T>
-     */
-    public function withRowMapper(callable $rowMapper): self
+    /** @param callable(array<array-key, mixed>): mixed $rowMapper */
+    public function setRowMapper(callable $rowMapper): void
     {
         $this->rowMapper = $rowMapper;
-
-        return $this;
     }
 
     #[Override]
     public function offsetExists($pageIndex): bool
     {
+        // AuraSqlPager::offsetExists() is unsupported, so existence follows offsetGet().
         return (bool) $this->offsetGet($pageIndex);
     }
 

--- a/tests/DbPagerTest.php
+++ b/tests/DbPagerTest.php
@@ -25,4 +25,14 @@ final class DbPagerTest extends TestCase
         $this->assertSame('perPage', $pager->perPage, 'Pager::$perPage must remain the original key string');
         $this->assertSame([2, 1, 3], $sqlQuery->perPageHistory, 'Each call must forward its own perPage to SqlQuery::getPages()');
     }
+
+    public function testNonPagesResultIsWrappedWhenRowMapperIsGiven(): void
+    {
+        $dbPager = new DbPager(new FakeMediaQueryLogger(), new FakeSqlQuery());
+        $pager = new Pager(perPage: 10, template: '/{?page}');
+
+        $pages = ($dbPager)('todo_list', [], $pager, null, static fn (array $row): array => $row);
+
+        $this->assertInstanceOf(MappedPages::class, $pages);
+    }
 }

--- a/tests/DbQueryModuleTest.php
+++ b/tests/DbQueryModuleTest.php
@@ -26,6 +26,7 @@ use Ray\MediaQuery\Queries\DynamicPerPageInterface;
 use Ray\MediaQuery\Queries\DynamicPerPageInvalidInterface;
 use Ray\MediaQuery\Queries\DynamicPerPageInvalidType;
 use Ray\MediaQuery\Queries\PagerEntityInterface;
+use Ray\MediaQuery\Queries\PagerFactoryInterface;
 use Ray\MediaQuery\Queries\PromiseAddInterface;
 use Ray\MediaQuery\Queries\PromiseItemInterface;
 use Ray\MediaQuery\Queries\PromiseListInterface;
@@ -65,6 +66,7 @@ class DbQueryModuleTest extends TestCase
             DynamicPerPageInvalidInterface::class,
             DynamicPerPageInvalidType::class,
             PagerEntityInterface::class,
+            PagerFactoryInterface::class,
             TodoFactoryInterface::class,
             TodoFactoryUnionInterface::class,
         ]);
@@ -247,6 +249,30 @@ class DbQueryModuleTest extends TestCase
         $this->assertInstanceOf(TodoConstruct::class, $page->data[0]);
         $log = (string) $this->logger;
         $this->assertStringContainsString('query: todo_list', $log);
+    }
+
+    public function testSelectPagerStaticFactory(): void
+    {
+        $todoList = $this->injector->getInstance(PagerFactoryInterface::class);
+        $list = $todoList->getStatic();
+        $page = $list[1];
+        assert($page instanceof Page);
+        assert(is_array($page->data));
+
+        $this->assertInstanceOf(TodoConstruct::class, $page->data[0]);
+        $this->assertSame('run', $page->data[0]->title);
+    }
+
+    public function testSelectPagerInjectionFactory(): void
+    {
+        $todoList = $this->injector->getInstance(PagerFactoryInterface::class);
+        $list = $todoList->getInjection();
+        $page = $list[1];
+        assert($page instanceof Page);
+        assert(is_array($page->data));
+
+        $this->assertInstanceOf(TodoConstruct::class, $page->data[0]);
+        $this->assertSame('RUN', $page->data[0]->title);
     }
 
     /** @return array<array<class-string>> */

--- a/tests/DbQueryModuleTest.php
+++ b/tests/DbQueryModuleTest.php
@@ -284,12 +284,7 @@ class DbQueryModuleTest extends TestCase
         $factoryInstances = TodoInjectionFactory::$instances;
         $this->assertGreaterThan(0, $factoryInstances);
 
-        $page = $list[1];
-        assert($page instanceof Page);
-        assert(is_array($page->data));
-
-        $this->assertInstanceOf(TodoConstruct::class, $page->data[0]);
-        $this->assertSame('RUN', $page->data[0]->title);
+        $this->assertNotNull($list[1]);
         $this->assertSame($factoryInstances, TodoInjectionFactory::$instances);
     }
 

--- a/tests/DbQueryModuleTest.php
+++ b/tests/DbQueryModuleTest.php
@@ -19,6 +19,7 @@ use Ray\MediaQuery\Exception\InvalidPerPageVarNameException;
 use Ray\MediaQuery\Exception\PerPageNotIntTypeException;
 use Ray\MediaQuery\Factory\FakeFactoryHelper;
 use Ray\MediaQuery\Factory\FakeFactoryHelperInterface;
+use Ray\MediaQuery\Factory\TodoInjectionFactory;
 use Ray\MediaQuery\Fake\Queries\TodoEntityNullableInterface;
 use Ray\MediaQuery\Fake\Queries\TodoFactoryInterface;
 use Ray\MediaQuery\Fake\Queries\TodoFactoryUnionInterface;
@@ -38,6 +39,7 @@ use Ray\MediaQuery\Queries\TodoListInterface;
 
 use function array_keys;
 use function assert;
+use function count;
 use function dirname;
 use function file_get_contents;
 use function is_array;
@@ -52,6 +54,8 @@ class DbQueryModuleTest extends TestCase
 
     protected function setUp(): void
     {
+        TodoInjectionFactory::resetInstances();
+
         $mediaQueries = Queries::fromClasses([
             TodoAddInterface::class,
             TodoItemInterface::class,
@@ -267,12 +271,26 @@ class DbQueryModuleTest extends TestCase
     {
         $todoList = $this->injector->getInstance(PagerFactoryInterface::class);
         $list = $todoList->getInjection();
+
+        $this->assertGreaterThan(0, count($list));
+        $this->assertSame(0, TodoInjectionFactory::$instances);
+
         $page = $list[1];
         assert($page instanceof Page);
         assert(is_array($page->data));
 
         $this->assertInstanceOf(TodoConstruct::class, $page->data[0]);
         $this->assertSame('RUN', $page->data[0]->title);
+        $factoryInstances = TodoInjectionFactory::$instances;
+        $this->assertGreaterThan(0, $factoryInstances);
+
+        $page = $list[1];
+        assert($page instanceof Page);
+        assert(is_array($page->data));
+
+        $this->assertInstanceOf(TodoConstruct::class, $page->data[0]);
+        $this->assertSame('RUN', $page->data[0]->title);
+        $this->assertSame($factoryInstances, TodoInjectionFactory::$instances);
     }
 
     /** @return array<array<class-string>> */

--- a/tests/Fake/Factory/TodoInjectionFactory.php
+++ b/tests/Fake/Factory/TodoInjectionFactory.php
@@ -7,9 +7,17 @@ use Ray\MediaQuery\EntityFactoryInterface;
 
 final class TodoInjectionFactory
 {
+    public static int $instances = 0;
+
     public function __construct(
-        private FakeFactoryHelperInterface $helper
-    ){
+        private FakeFactoryHelperInterface $helper,
+    ) {
+        self::$instances++;
+    }
+
+    public static function resetInstances(): void
+    {
+        self::$instances = 0;
     }
 
     public function factory($id, $title): TodoConstruct

--- a/tests/Fake/MappedPagesFakePages.php
+++ b/tests/Fake/MappedPagesFakePages.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+
+final class MappedPagesFakePages implements PagesInterface
+{
+    public mixed $setValue = null;
+    public bool $unsetCalled = false;
+
+    public function __construct(
+        private mixed $value,
+    ) {
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        unset($offset);
+
+        return true;
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        unset($offset);
+
+        return $this->value;
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        unset($offset);
+
+        $this->setValue = $value;
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($offset);
+
+        $this->unsetCalled = true;
+    }
+
+    public function count(): int
+    {
+        return 1;
+    }
+}

--- a/tests/Fake/Queries/PagerFactoryInterface.php
+++ b/tests/Fake/Queries/PagerFactoryInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery\Queries;
+
+use Ray\MediaQuery\Annotation\DbQuery;
+use Ray\MediaQuery\Annotation\Pager;
+use Ray\MediaQuery\Factory\TodoEntityFactory;
+use Ray\MediaQuery\Factory\TodoInjectionFactory;
+use Ray\MediaQuery\Pages;
+
+interface PagerFactoryInterface
+{
+    #[DbQuery('todo_list', factory: TodoEntityFactory::class), Pager(perPage: 10, template: '/{?page}')]
+    public function getStatic(): Pages;
+
+    #[DbQuery('todo_list', factory: TodoInjectionFactory::class), Pager(perPage: 10, template: '/{?page}')]
+    public function getInjection(): Pages;
+}

--- a/tests/MappedPagesTest.php
+++ b/tests/MappedPagesTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+
+use PHPUnit\Framework\TestCase;
+use Ray\AuraSqlModule\Pagerfanta\Page;
+use ReflectionClass;
+
+final class MappedPagesTest extends TestCase
+{
+    public function testMapsPageData(): void
+    {
+        $page = $this->page([['id' => '1', 'title' => 'run'], 'already-mapped']);
+        $pages = new MappedPages(
+            $this->pages($page),
+            static fn (array $row): array => ['title' => $row['title']],
+        );
+
+        $mappedPage = $pages[1];
+
+        $this->assertTrue(isset($pages[1]));
+        $this->assertInstanceOf(Page::class, $mappedPage);
+        $data = $mappedPage->data;
+        $this->assertIsArray($data);
+        $this->assertIsArray($data[0]);
+        $this->assertSame('run', $data[0]['title']);
+        $this->assertSame('already-mapped', $data[1]);
+    }
+
+    public function testReturnsNonPageValuesAsIs(): void
+    {
+        $pages = new MappedPages(
+            $this->pages('not-page'),
+            static fn (array $row): array => $row,
+        );
+
+        $this->assertSame('not-page', $pages[1]);
+    }
+
+    public function testDelegatesMutationAndCount(): void
+    {
+        $delegate = $this->pages($this->page([]));
+        $pages = new MappedPages(
+            $delegate,
+            static fn (array $row): array => $row,
+        );
+
+        $pages[1] = 'set';
+        unset($pages[1]);
+
+        $this->assertSame(1, $pages->count());
+    }
+
+    private function page(mixed $data): Page
+    {
+        $reflection = new ReflectionClass(Page::class);
+        $page = $reflection->newInstanceWithoutConstructor();
+        $page->data = $data;
+
+        return $page;
+    }
+
+    private function pages(mixed $value): PagesInterface
+    {
+        return new class ($value) implements PagesInterface {
+            public mixed $setValue = null;
+            public bool $unsetCalled = false;
+
+            public function __construct(
+                private mixed $value,
+            ) {
+            }
+
+            public function offsetExists(mixed $offset): bool
+            {
+                unset($offset);
+
+                return true;
+            }
+
+            public function offsetGet(mixed $offset): mixed
+            {
+                unset($offset);
+
+                return $this->value;
+            }
+
+            public function offsetSet(mixed $offset, mixed $value): void
+            {
+                unset($offset);
+
+                $this->setValue = $value;
+            }
+
+            public function offsetUnset(mixed $offset): void
+            {
+                unset($offset);
+
+                $this->unsetCalled = true;
+            }
+
+            public function count(): int
+            {
+                return 1;
+            }
+        };
+    }
+}

--- a/tests/MappedPagesTest.php
+++ b/tests/MappedPagesTest.php
@@ -31,7 +31,7 @@ final class MappedPagesTest extends TestCase
         $this->assertIsArray($data);
         $this->assertIsArray($data[0]);
         $this->assertSame('run', $data[0]['title']);
-        $this->assertSame(2, $data[0]['calls']);
+        $this->assertSame(1, $data[0]['calls']);
         $this->assertSame('already-mapped', $data[1]);
         $this->assertSame([['id' => '1', 'title' => 'run'], 'already-mapped'], $page->data);
     }

--- a/tests/MappedPagesTest.php
+++ b/tests/MappedPagesTest.php
@@ -13,20 +13,27 @@ final class MappedPagesTest extends TestCase
     public function testMapsPageData(): void
     {
         $page = $this->page([['id' => '1', 'title' => 'run'], 'already-mapped']);
+        $calls = 0;
         $pages = new MappedPages(
             $this->pages($page),
-            static fn (array $row): array => ['title' => $row['title']],
+            static function (array $row) use (&$calls): array {
+                $calls++;
+
+                return ['title' => $row['title'], 'calls' => $calls];
+            },
         );
 
+        $this->assertTrue(isset($pages[1]));
         $mappedPage = $pages[1];
 
-        $this->assertTrue(isset($pages[1]));
         $this->assertInstanceOf(Page::class, $mappedPage);
         $data = $mappedPage->data;
         $this->assertIsArray($data);
         $this->assertIsArray($data[0]);
         $this->assertSame('run', $data[0]['title']);
+        $this->assertSame(2, $data[0]['calls']);
         $this->assertSame('already-mapped', $data[1]);
+        $this->assertSame([['id' => '1', 'title' => 'run'], 'already-mapped'], $page->data);
     }
 
     public function testReturnsNonPageValuesAsIs(): void
@@ -50,6 +57,8 @@ final class MappedPagesTest extends TestCase
         $pages[1] = 'set';
         unset($pages[1]);
 
+        $this->assertSame('set', $delegate->setValue);
+        $this->assertTrue($delegate->unsetCalled);
         $this->assertSame(1, $pages->count());
     }
 
@@ -62,49 +71,8 @@ final class MappedPagesTest extends TestCase
         return $page;
     }
 
-    private function pages(mixed $value): PagesInterface
+    private function pages(mixed $value): MappedPagesFakePages
     {
-        return new class ($value) implements PagesInterface {
-            public mixed $setValue = null;
-            public bool $unsetCalled = false;
-
-            public function __construct(
-                private mixed $value,
-            ) {
-            }
-
-            public function offsetExists(mixed $offset): bool
-            {
-                unset($offset);
-
-                return true;
-            }
-
-            public function offsetGet(mixed $offset): mixed
-            {
-                unset($offset);
-
-                return $this->value;
-            }
-
-            public function offsetSet(mixed $offset, mixed $value): void
-            {
-                unset($offset);
-
-                $this->setValue = $value;
-            }
-
-            public function offsetUnset(mixed $offset): void
-            {
-                unset($offset);
-
-                $this->unsetCalled = true;
-            }
-
-            public function count(): int
-            {
-                return 1;
-            }
-        };
+        return new MappedPagesFakePages($value);
     }
 }

--- a/tests/PageRowMapperFactoryTest.php
+++ b/tests/PageRowMapperFactoryTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+
+use PHPUnit\Framework\TestCase;
+use Ray\Di\InjectorInterface;
+use Ray\Di\Name;
+use Ray\MediaQuery\Annotation\DbQuery;
+use Ray\MediaQuery\Factory\TodoInjectionFactory;
+
+final class PageRowMapperFactoryTest extends TestCase
+{
+    public function testInjectedFactoryIsResolvedLazilyAndReused(): void
+    {
+        $injector = new class (new class {
+            public function factory(string $id, string $title): string
+            {
+                return $id . ':' . $title;
+            }
+        }) implements InjectorInterface {
+            public int $instances = 0;
+
+            public function __construct(
+                private object $instance,
+            ) {
+            }
+
+            public function getInstance($interface, $name = Name::ANY): object
+            {
+                unset($interface, $name);
+                $this->instances++;
+
+                return $this->instance;
+            }
+        };
+        $factory = new PageRowMapperFactory('factory', $injector);
+        $rowMapper = $factory->create(new DbQuery('todo_list', factory: TodoInjectionFactory::class));
+
+        $this->assertIsCallable($rowMapper);
+        $this->assertSame(0, $injector->instances);
+
+        $this->assertSame('1:run', $rowMapper(['1', 'run']));
+        $this->assertSame(1, $injector->instances);
+
+        $this->assertSame('2:walk', $rowMapper(['2', 'walk']));
+        $this->assertSame(1, $injector->instances);
+    }
+}


### PR DESCRIPTION
## Summary

- Thread `DbQuery(factory: ...)` into the pager path through a row mapper.
- Keep concrete `Pages` return types working by mapping cloned `Page->data` inside `Pages` when the standard pager wrapper is used.
- Add regression coverage for pager hydration with both static and injected factories, plus fallback page mapping coverage.
- Name the pager-specific mapper builder `PageRowMapperFactory::create()` so the code describes row mapping instead of page hydration.
- Address CodeRabbit feedback by avoiding in-place `Page` mutation, sharing row mapping through `PageRows::map()`, and tightening delegation tests.
- Apply follow-ups: delegate `MappedPages::offsetExists()`, document the Aura pager `offsetExists()` constraint in `Pages`, rename `withRowMapper()` to `setRowMapper()`, and seal `PageRows` against instantiation.
- Defer injected pager row factory resolution until the first row is mapped, so `count($pages)` and pass-through `Pages` usage do not construct the injected factory.

## Root Cause

`DbQueryInterceptor` handled `#[Pager]` before it created the normal `FetchFactoryInterface` fetcher. As a result, pager queries only forwarded an entity class into AuraSqlModule, so `DbQuery(factory: ...)` was ignored for paginated results. The injected factory path also needed to preserve pager laziness: factory construction should happen when rows are mapped, not when the `Pages` object is returned.

## Validation

- `composer tests` (local PHP 8.4 tooling; `103 tests, 184 assertions`)
- `vendor/bin/phpunit` (local PHP 8.5 runtime; `103 tests, 184 assertions`)
- `composer pcov` (`103 tests, 184 assertions`; 100% classes/methods/lines)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional per-row mapping for paginated query results — allows supplying a row-mapper to transform page data during pagination; non-page results are preserved or wrapped so mapping applies consistently.

* **Tests**
  * Added tests covering row-mapping behavior, wrapping of non-page results, mapping delegation and mutation semantics, and lazy/reused factory-based mappers for both static and injection-based scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
