### PR TITLE
Add BDR + BEAR.Async parallel SQL recipe

### DIFF
--- a/BDR_PATTERN-ja.md
+++ b/BDR_PATTERN-ja.md
@@ -709,6 +709,10 @@ public function getProduct(string $id): ProductDomainObject;
 
 重要なのは、いつどのようにデータをロードするかについて**意図的であること**です。ファクトリーパターンは、この戦略を完全にコントロールする力を与えます。
 
+## 関連レシピ
+
+- [BDR + BEAR.Async: 並列 SQL レシピ](./BEAR_ASYNC_RECIPE-ja.md) — 各リポジトリ呼び出しを `ResourceObject` で包むと、`#[Embed]` がアプリケーション境界でそれらを並列実行する。
+
 ## 参考文献
 
 - [Object-Relational Mapping is the Vietnam of Computer Science](https://blog.codinghorror.com/object-relational-mapping-is-the-vietnam-of-computer-science/) - Jeff Atwood (2006)

--- a/BDR_PATTERN.md
+++ b/BDR_PATTERN.md
@@ -661,6 +661,10 @@ public function getProduct(string $id): ProductDomainObject;
 
 The key is **being intentional** about when and how you load data. The factory pattern gives you complete control over this strategy.
 
+## Related Recipes
+
+- [BDR + BEAR.Async: Parallel SQL Recipe](./BEAR_ASYNC_RECIPE.md) — wrap each Repository call in a `ResourceObject` and let `#[Embed]` parallelise them at the application boundary.
+
 ## References
 
 - [Object-Relational Mapping is the Vietnam of Computer Science](https://blog.codinghorror.com/object-relational-mapping-is-the-vietnam-of-computer-science/) - Jeff Atwood (2006)

--- a/BEAR_ASYNC_RECIPE-ja.md
+++ b/BEAR_ASYNC_RECIPE-ja.md
@@ -1,0 +1,105 @@
+# レシピ: BDR + BEAR.Async で SQL を並列化
+
+BDR のリポジトリが宣言するのは「**何を**問い合わせるか」であって、「**いつ**」「**どう**」実行するかではありません。この最後の 1 ピースのおかげで、エンティティごとの SQL を**何の追加実装もなしに並列実行**できます。各リポジトリ呼び出しを `ResourceObject` の中に置けば、[BEAR.Async](https://github.com/bearsunday/BEAR.Async) が `#[Embed]` を経由してそれらを並列に走らせます。リポジトリの実装も SQL も変わりません。
+
+このレシピは 2 つのライブラリの組み合わせ方を示します。どちらにも新しい抽象は持ち込みません。呼び出し側の規約が 2 つあるだけです。
+
+## こんなときに
+
+- 1 ページで独立した SQL を複数発行したい（user + posts + comments、ダッシュボードの各ウィジェット、検索ファセットなど）
+- すでにクエリごとに SQL を書いていて、ORM に巨大な 1 文に融合されたくない
+- 開発時は同期実行（PHP-FPM、デバッグしやすい）にしておき、アプリケーションの境界でだけ並列実行に切り替えたい（PHP-FPM / Apache なら ext-parallel、常駐サーバなら ext-swoole）
+
+## 前提
+
+```bash
+composer require ray/media-query
+composer require bear/async
+```
+
+[BDR パターン](./BDR_PATTERN-ja.md)（`#[DbQuery]` インターフェース・ファクトリ・不変ドメインオブジェクト）に既に親しんでいる前提です。BEAR.Async は BEAR.Sunday スタイルのリソース（`ResourceObject` + `#[Embed]`）を期待します。
+
+## レシピ
+
+SQL ごとに `ResourceObject` を分け、上位の集約リソースから `#[Embed]` で束ねます。
+
+```php
+use BEAR\Resource\Annotation\Embed;
+use BEAR\Resource\ResourceObject;
+use Ray\MediaQuery\Annotation\DbQuery;
+
+// 1. 不変ドメインオブジェクト — リポジトリが返すスナップショット
+final class UserAccount
+{
+    public function __construct(
+        public readonly int $id,
+        public readonly string $name,
+    ) {
+    }
+}
+
+// 2. BDR リポジトリ — SQL は var/sql/user.sql に置く。
+//    UserFactory が行を UserAccount にハイドレートする（詳細は BDR_PATTERN-ja.md 参照）。
+interface UserRepositoryInterface
+{
+    #[DbQuery('user', factory: UserFactory::class)]
+    public function getUser(int $id): UserAccount;
+}
+
+// 3. SQL 1 つにつき ResourceObject 1 つ — 小さく、責務を 1 つだけ持つ
+class User extends ResourceObject
+{
+    public function __construct(private UserRepositoryInterface $repo)
+    {
+    }
+
+    public function onGet(int $id): static
+    {
+        $this->body = ['user' => $this->repo->getUser($id)];
+
+        return $this;
+    }
+}
+
+// 4. 集約リソース — リソース間の関係を宣言するだけ。
+//    3 つの Embed は AsyncLinker が自動で並列実行する。
+class UserDashboard extends ResourceObject
+{
+    #[Embed(rel: 'user',     src: 'app://self/user{?id}')]
+    #[Embed(rel: 'posts',    src: 'app://self/user/posts{?id}')]
+    #[Embed(rel: 'comments', src: 'app://self/user/comments{?id}')]
+    public function onGet(int $id): static
+    {
+        return $this;
+    }
+}
+```
+
+これでレシピは終わりです。ダッシュボードは並行性・スレッド・コルーチン・Promise のいずれにも触れていません。3 つのリポジトリも互いに何も知りません。
+
+## なぜ動くか
+
+- **BDR が SQL を宣言的に保つ**: 各 `#[DbQuery]` メソッドは 1 クエリを記述し、不変ドメインオブジェクトを返します。SQL は `var/sql/*.sql` のまま。
+- **`ResourceObject` がクエリに URI を与える**: `app://self/user?id=1` は URI です。`#[Embed]` は「この集約はそのリソースを必要とする」 という**関係**を宣言します。呼び出しではありません。
+- **AsyncLinker が実行戦略を選ぶ**: 実行時に 3 つの `#[Embed]` を独立したリクエストの 1 つのレベルとして見て、ext-parallel のワーカー（PHP-FPM / Apache）または Swoole のコルーチン（常駐サーバ）で並列に発行します。どちらの拡張もない場合は同じコードが逐次実行されますが、PHP-FPM は 1 リクエスト 1 プロセスなのでそれで問題ありません。
+
+呼び出し側のコードは変わりません。「逐次」か「並列」かはアプリケーションの境界（エントリポイント・モジュール）で決まり、リポジトリやリソースの中では決めません。
+
+## 計測
+
+BEAR.Async は 8 個の独立した SQL バックエンドの埋め込みを持つダッシュボードを使って、コールド CLI ベンチマークとスチーディステート HTTP ベンチマーク（`wrk`）を同梱しています。数値とアダプタ選定ガイドは [BEAR.Async / docs/benchmark-results.md](https://github.com/bearsunday/BEAR.Async/blob/1.x/docs/benchmark-results.md) を参照してください。
+
+要点は: 1 ページに独立した SQL が 2 つ以上あれば、このレシピで埋め込み数ぶんだけページが速くなります（プールやランタイムのオーバーヘッドを差し引いて）。リポジトリのコードは一切変わりません。
+
+## Swoole での注意
+
+ext-swoole 上で動かす場合、コルーチンはプロセスメモリを共有するため、`PDO` 接続をコルーチン境界をまたいで共有してはいけません。BEAR.Async の `PdoPoolModule` をインストールして、各コルーチンがプールから `PDO` を借りるようにします。接続取得は遅延され、`#[Embed]` を宣言した時点ではプールには触れず、各リクエストが実際に実行されるときに取得します。
+
+詳細は [BEAR.Async README — Swoole execution](https://github.com/bearsunday/BEAR.Async#swoole-execution-ext-swoole) を参照してください。
+
+## 関連
+
+- [BDR パターン解説](./BDR_PATTERN-ja.md) — リポジトリ + ファクトリ + ドメインオブジェクトの土台
+- [BEAR.Async](https://github.com/bearsunday/BEAR.Async) — BEAR.Sunday 向け `#[Embed]` 並列実行ライブラリ
+- [BEAR.Async ベンチマーク結果](https://github.com/bearsunday/BEAR.Async/blob/1.x/docs/benchmark-results.md) — コールド CLI と スチーディステート HTTP の実測値
+- [並列リソース実行マニュアル (BEAR.Sunday ドキュメント)](https://bearsunday.github.io/manuals/1.0/ja/async.html)

--- a/BEAR_ASYNC_RECIPE.md
+++ b/BEAR_ASYNC_RECIPE.md
@@ -1,0 +1,105 @@
+# Recipe: Parallel SQL with BDR + BEAR.Async
+
+A BDR Repository describes **what** to query, not **when** or **how**. That last piece is what lets per-entity SQL go parallel for free — once each Repository call lives inside its own `ResourceObject`, [BEAR.Async](https://github.com/bearsunday/BEAR.Async) parallelises them through `#[Embed]` without any change to the Repository or its SQL.
+
+This recipe shows how to compose the two libraries. No new abstraction is introduced on either side — only a pair of conventions on the call site.
+
+## When this is useful
+
+- One page needs to issue several independent SQL queries (user + posts + comments, dashboard widgets, search facets, …)
+- You already write SQL per query and don't want an ORM to fuse them into one mega-statement
+- You want to keep development synchronous (PHP-FPM, easy debugging) and only switch to parallel execution at the application boundary (ext-parallel for PHP-FPM / Apache, ext-swoole for long-running servers)
+
+## Prerequisites
+
+```bash
+composer require ray/media-query
+composer require bear/async
+```
+
+You should already be comfortable with the [BDR Pattern](./BDR_PATTERN.md) — `#[DbQuery]` interface, factory, immutable domain object. BEAR.Async expects BEAR.Sunday-style resources (`ResourceObject` + `#[Embed]`).
+
+## The recipe
+
+Split each SQL into its own `ResourceObject`, then let an aggregate resource compose them with `#[Embed]`:
+
+```php
+use BEAR\Resource\Annotation\Embed;
+use BEAR\Resource\ResourceObject;
+use Ray\MediaQuery\Annotation\DbQuery;
+
+// 1. Immutable domain object — the snapshot returned by the Repository
+final class UserAccount
+{
+    public function __construct(
+        public readonly int $id,
+        public readonly string $name,
+    ) {
+    }
+}
+
+// 2. BDR Repository — SQL lives in var/sql/user.sql.
+//    UserFactory hydrates the row into UserAccount (see BDR_PATTERN.md).
+interface UserRepositoryInterface
+{
+    #[DbQuery('user', factory: UserFactory::class)]
+    public function getUser(int $id): UserAccount;
+}
+
+// 3. One ResourceObject per SQL — small, focused, no orchestration
+class User extends ResourceObject
+{
+    public function __construct(private UserRepositoryInterface $repo)
+    {
+    }
+
+    public function onGet(int $id): static
+    {
+        $this->body = ['user' => $this->repo->getUser($id)];
+
+        return $this;
+    }
+}
+
+// 4. Aggregate resource — declares the relationship, nothing else.
+//    AsyncLinker parallelises the three Embeds automatically.
+class UserDashboard extends ResourceObject
+{
+    #[Embed(rel: 'user',     src: 'app://self/user{?id}')]
+    #[Embed(rel: 'posts',    src: 'app://self/user/posts{?id}')]
+    #[Embed(rel: 'comments', src: 'app://self/user/comments{?id}')]
+    public function onGet(int $id): static
+    {
+        return $this;
+    }
+}
+```
+
+That is the entire recipe. The dashboard never mentions concurrency, threads, coroutines, or promises. The three Repositories never coordinate.
+
+## How it works
+
+- **BDR keeps SQL declarative**: each `#[DbQuery]` method describes one query and returns an immutable domain object. SQL stays in `var/sql/*.sql`.
+- **`ResourceObject` makes the query addressable**: `app://self/user?id=1` is a URI. `#[Embed]` declares "this aggregate needs that resource" — a relationship, not a call.
+- **AsyncLinker picks the execution strategy**: at runtime it sees the three `#[Embed]` declarations as a level of independent requests and dispatches them in parallel via ext-parallel workers (PHP-FPM / Apache) or Swoole coroutines (long-running server). With neither extension loaded the same code runs sequentially per request — which is fine for PHP-FPM, since each request is its own process.
+
+The call site never changes. Choosing sequential vs. parallel happens at the application boundary (entrypoint / module), not inside the Repository or the resource.
+
+## Measured impact
+
+BEAR.Async ships cold one-shot CLI benchmarks and steady-state HTTP benchmarks (`wrk`) for a dashboard that fans out to 8 independent SQL-backed embeds. Numbers and adapter selection guidance live in [BEAR.Async / docs/benchmark-results.md](https://github.com/bearsunday/BEAR.Async/blob/1.x/docs/benchmark-results.md).
+
+The headline: as soon as a page has more than one independent SQL, this recipe makes the page faster by the number of embeds (minus pool/runtime overhead). The Repository code stays unchanged.
+
+## Swoole notes
+
+When running on ext-swoole, coroutines share process memory and must not share a `PDO` connection across boundaries. Install `PdoPoolModule` from BEAR.Async so each coroutine borrows a pooled `PDO`. Connection acquisition is lazy — the pool is not touched at `#[Embed]` declaration time, only when each request actually runs.
+
+See [BEAR.Async README — Swoole execution](https://github.com/bearsunday/BEAR.Async#swoole-execution-ext-swoole) for details.
+
+## See also
+
+- [BDR Pattern Guide](./BDR_PATTERN.md) — the Repository + Factory + Domain Object foundation
+- [BEAR.Async](https://github.com/bearsunday/BEAR.Async) — `#[Embed]` parallelisation library for BEAR.Sunday
+- [BEAR.Async benchmark results](https://github.com/bearsunday/BEAR.Async/blob/1.x/docs/benchmark-results.md) — cold CLI and steady-state HTTP numbers
+- [Parallel Resource Execution manual (BEAR.Sunday docs)](https://bearsunday.github.io/manuals/1.0/en/async.html)

--- a/README.md
+++ b/README.md
@@ -731,5 +731,6 @@ This is more than a technical solution. It's a recognition that different paradi
 ## Learn More
 
 - [BDR Pattern Guide](./BDR_PATTERN.md)
+- [BDR + BEAR.Async — Parallel SQL Recipe](./BEAR_ASYNC_RECIPE.md)
 - [Demo Application](./demo/)
 - [llms-full.txt](https://ray-di.github.io/Ray.MediaQuery/llms-full.txt) — condensed reference for AI agents


### PR DESCRIPTION
## Summary

- New cross-library recipe showing how to combine the BDR pattern with [BEAR.Async](https://github.com/bearsunday/BEAR.Async) so that per-entity SQL queries run in parallel without changing the Repository or its SQL.
- Each `#[DbQuery]` Repository call is placed inside its own `ResourceObject`; an aggregate `ResourceObject` declares the relationship with `#[Embed]`, and `AsyncLinker` selects the execution strategy (ext-parallel workers for PHP-FPM / Apache, Swoole coroutines for long-running servers) at the application boundary.
- No new abstraction on either side — only convention on the call site. Ray.MediaQuery and BEAR.Async are both unmodified.

## Files

- `BEAR_ASYNC_RECIPE.md` — English recipe
- `BEAR_ASYNC_RECIPE-ja.md` — Japanese recipe
- `BDR_PATTERN.md`, `BDR_PATTERN-ja.md` — new "Related Recipes" / "関連レシピ" link
- `README.md` — "Learn More" link

## Context

BEAR.Async 1.x removed `SqlBatch` and the `BEAR\Projection\` namespace ([BEAR.Async#24](https://github.com/bearsunday/BEAR.Async/pull/24)), replacing the previous "SQL batch" example in the BEAR.Sunday manual ([bearsunday.github.io#359](https://github.com/bearsunday/bearsunday.github.io/pull/359)) with the BDR + `#[Embed]` recipe. This PR adds the corresponding entry on the Ray.MediaQuery side so BDR users can discover the same recipe from this repo.

## Test plan

- [ ] Verify Markdown renders cleanly on GitHub (especially fenced code blocks and tables)
- [ ] Confirm cross-links resolve: `BDR_PATTERN.md` → `BEAR_ASYNC_RECIPE.md`, `BDR_PATTERN-ja.md` → `BEAR_ASYNC_RECIPE-ja.md`, `README.md` → `BEAR_ASYNC_RECIPE.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new recipe documentation for combining BDR with BEAR.Async, available in both English and Japanese versions, including examples and implementation guidance.
  * Updated existing pattern documentation with cross-references to the new recipe.
  * Updated README with a link to the new recipe in the "Learn More" section.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ray-di/Ray.MediaQuery/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->