### PR TITLE
Complete the tutorial answer tree and note Ch.13's non-shipped fakes

### DIFF
--- a/docs/tutorial/README.ja.md
+++ b/docs/tutorial/README.ja.md
@@ -88,7 +88,9 @@ docs/tutorial/src/
 │   ├── ArticleStatsFactory.php      # DI ファクトリ
 │   ├── MarkdownExcerpter.php        # ファクトリへの注入対象
 │   ├── ArticleSearchResult.php      # SELECT 用 PostQueryInterface
-│   └── CreatedArticle.php           # DML + SELECT 用 PostQueryInterface
+│   ├── CreatedArticle.php           # DML + SELECT 用 PostQueryInterface
+│   └── Exception/
+│       └── UnexpectedRowException.php  # 結果クラスが投げるドメイン例外
 └── sql/
     ├── article_add.sql
     ├── article_create_and_get.sql
@@ -1485,6 +1487,8 @@ First hit: Post #3
 ### 考え方
 
 `ArticleQueryInterface` は契約。プロダクションでは Ray.MediaQuery が SQLite/MySQL を叩く実装を自動生成するが、テストでは「Fake 実装」を bind すれば DB なしでロジックを検証できる。
+
+> この章は `run.php` から実行しない解説章なので、ここで書く `UnsupportedQueryException` と `FakeArticleQuery` は答えコード (`docs/tutorial/src/`) には含めていない（統合 `run.php` が使わないため）。自分の `mywork/` 配下に写経して動かしてほしい。答えに収録されているドメイン例外は、第12章・補章の結果クラスが実際に使う `Blog/Exception/UnexpectedRowException.php` のみである。
 
 ### Step 1. Fake 実装を書く
 


### PR DESCRIPTION
## Summary

Two small documentation-accuracy fixes to the hands-on tutorial (`docs/tutorial/README.ja.md`). Docs only — no code or behavior changes.

- **Ch.0** — the "完成形のディレクトリ構成" tree omitted `Blog/Exception/UnexpectedRowException.php`, which exists in the answer code and is used by Ch.12 / the Appendix. Added it.
- **Ch.13** — the chapter introduces `UnsupportedQueryException` and `FakeArticleQuery`, which are intentionally absent from the executed answer (`docs/tutorial/src/`) because Ch.13 is a non-executed explanatory chapter. Added a note so readers don't look for them in the answer tree.

## Scope note

This PR was originally larger — it also relabeled the Ch.9 / Ch.10 / Ch.11 "expected output" reference frames and introduced a third "写経 run.php" frame. That part was reverted: the tutorial already carries a global disclaimer telling readers that ids/counts/strings vary and to check structure rather than exact values, so the relabeling added cognitive overhead without a proportional benefit. Only the two clear accuracy fixes above remain.

## Verification

`composer tutorial` (the CI integration check, assertions enabled) still passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated tutorial docs and directory diagram to show the completed example layout.
  * Added a note in Chapter 13 clarifying that the chapter’s test strategy examples are not executed by the integrated runner and that some sample pieces must be manually added to the learner’s workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->