### PR TITLE
Fix incorrect return type and PHP version in docs

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -151,7 +151,7 @@ interface UserRepository
 interface UserRepository
 {
     #[DbQuery('user_stats', type: 'row')]
-    public function getStats(string $id): array;  // ['total' => 10, 'active' => 5]
+    public function getStats(string $id): ?array;  // ['total' => 10, 'active' => 5], or null when no row matches
 }
 ```
 

--- a/docs/tutorial/README.ja.md
+++ b/docs/tutorial/README.ja.md
@@ -571,7 +571,7 @@ Hello
 - 戻り値型 `Article|null` (単一) や docblock `@return array<Article>` (複数) を見て、フレームワークが `Article` を組み立てる。
 - 今回の `Article` は constructor を持つので、`FetchNewInstance` が選ばれて `PDO::FETCH_FUNC` で組み立てられる。**SELECT カラム順が constructor 引数順にそのまま渡される**。詳細は次章。
 - Constructor Promotion のおかげで getter / setter は不要。`readonly` で意図せぬ変更を防ぐ。
-- PHP 8.4 以降なら `final readonly class Article { ... }` と書けばさらに簡潔。
+- PHP 8.2 以降なら `final readonly class Article { ... }` と書けばさらに簡潔。
 
 ---
 


### PR DESCRIPTION
## Summary

Two factual corrections to the documentation:

- `docs/reference.md` — a `type: 'row'` query returns `null` when no row matches (`SqlQuery::getRow()` returns `null` on an empty result set), so the example return type must be `?array`, not `array`. This also aligns it with the other single-row examples in the same file (`item(): User|null`, `find(): User|null`).
- `docs/tutorial/README.ja.md` (Ch.6) — `readonly` classes have been available since PHP 8.2, not 8.4.

## Why

The reference example declared a non-nullable `array` return for a single-row query, which would raise a `TypeError` at runtime whenever the query matches no row. The tutorial cited the wrong PHP version for `readonly` classes.

## Validation

- `?array` behavior verified against `src/SqlQuery.php` (`getRow()` returns `null` when the result set is empty).
- `readonly` class availability confirmed as PHP 8.2.

## Notes

Earlier revisions of this PR also changed the `--no-dev` install flow, `autoload` registration, extension prerequisites, and run.php output labels. Those were dropped as out-of-scope churn (the original install/autoload wording was already consistent, and the framework's required extensions are enforced by `composer install`), leaving only the two correctness fixes above.
