### PR TITLE
Improve branch coverage for uncovered paths

### DIFF
--- a/tests/Fake/FromDir/TodoClass.php
+++ b/tests/Fake/FromDir/TodoClass.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery\FromDir;
+
+final class TodoClass
+{
+}

--- a/tests/Fake/FromDirInvalidCase/NoClass.php
+++ b/tests/Fake/FromDirInvalidCase/NoClass.php
@@ -1,0 +1,3 @@
+<?php
+
+declare(strict_types=1);

--- a/tests/InsertedRowTest.php
+++ b/tests/InsertedRowTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+
+use Aura\Sql\ExtendedPdoInterface;
+use PDOStatement;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Ray\MediaQuery\Result\InsertedRow;
+use Ray\MediaQuery\Result\PostQueryContext;
+
+final class InsertedRowTest extends TestCase
+{
+    /**
+     * @param string|false $lastInsertId
+     */
+    #[DataProvider('emptyLastInsertIds')]
+    public function testFromContextNormalizesEmptyLastInsertId(string|false $lastInsertId): void
+    {
+        $pdo = $this->createStub(ExtendedPdoInterface::class);
+        $pdo->method('lastInsertId')->willReturn($lastInsertId);
+
+        $result = InsertedRow::fromContext(new PostQueryContext(
+            $this->createStub(PDOStatement::class),
+            $pdo,
+            ['label' => 'empty'],
+        ));
+
+        $this->assertSame(['label' => 'empty'], $result->values);
+        $this->assertNull($result->id);
+    }
+
+    /**
+     * @return array<string, array{string|false}>
+     */
+    public static function emptyLastInsertIds(): array
+    {
+        return [
+            'false' => [false],
+            'empty string' => [''],
+            'zero string' => ['0'],
+        ];
+    }
+}

--- a/tests/InsertedRowTest.php
+++ b/tests/InsertedRowTest.php
@@ -13,9 +13,6 @@ use Ray\MediaQuery\Result\PostQueryContext;
 
 final class InsertedRowTest extends TestCase
 {
-    /**
-     * @param string|false $lastInsertId
-     */
     #[DataProvider('emptyLastInsertIds')]
     public function testFromContextNormalizesEmptyLastInsertId(string|false $lastInsertId): void
     {
@@ -32,9 +29,7 @@ final class InsertedRowTest extends TestCase
         $this->assertNull($result->id);
     }
 
-    /**
-     * @return array<string, array{string|false}>
-     */
+    /** @return array<string, array{string|false}> */
     public static function emptyLastInsertIds(): array
     {
         return [

--- a/tests/PagesTest.php
+++ b/tests/PagesTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\MediaQuery;
+
+use Aura\Sql\ExtendedPdoInterface;
+use PHPUnit\Framework\TestCase;
+use Ray\AuraSqlModule\Pagerfanta\AuraSqlPagerInterface;
+
+final class PagesTest extends TestCase
+{
+    public function testOffsetGetReturnsNullWhenDelegateHasNoPage(): void
+    {
+        $delegate = $this->createStub(AuraSqlPagerInterface::class);
+        $delegate->method('offsetGet')->willReturn(null);
+
+        $pages = new Pages(
+            $delegate,
+            $this->createStub(ExtendedPdoInterface::class),
+            'SELECT 1',
+            [],
+        );
+
+        $this->assertFalse(isset($pages[3]));
+        $this->assertNull($pages[3]);
+    }
+}

--- a/tests/QueriesTest.php
+++ b/tests/QueriesTest.php
@@ -6,7 +6,9 @@ namespace Ray\MediaQuery;
 
 use PHPUnit\Framework\TestCase;
 use Ray\MediaQuery\FromDir\TodoAddInterface;
+use Ray\MediaQuery\FromDir\TodoClass;
 use Ray\MediaQuery\FromDir\TodoItemInterface;
+use ReflectionMethod;
 
 use function sort;
 
@@ -14,7 +16,7 @@ class QueriesTest extends TestCase
 {
     public function testFromClasses(): void
     {
-        $classes = [TodoAddInterface::class, TodoItemInterface::class];
+        $classes = [TodoAddInterface::class, TodoClass::class, TodoItemInterface::class];
         $mediaQueries = Queries::fromClasses($classes);
         $this->assertSame($classes, $mediaQueries->classes);
     }
@@ -26,6 +28,7 @@ class QueriesTest extends TestCase
         sort($classes);
         $this->assertSame([
             TodoAddInterface::class,
+            TodoClass::class,
             TodoItemInterface::class,
         ], $classes);
     }
@@ -37,6 +40,7 @@ class QueriesTest extends TestCase
         sort($classes);
         $this->assertSame([
             TodoAddInterface::class,
+            TodoClass::class,
             TodoItemInterface::class,
         ], $classes);
     }
@@ -45,5 +49,13 @@ class QueriesTest extends TestCase
     {
         $mediaQueries = Queries::fromDir(__DIR__ . '/Fake/FromDirInvalidCase');
         $this->assertEmpty($mediaQueries->classes);
+    }
+
+    public function testTokenListsWithoutClassHaveNoClass(): void
+    {
+        $method = new ReflectionMethod(ClassesInDirectories::class, 'extractClassName');
+
+        $this->assertNull($method->invoke(null, []));
+        $this->assertNull($method->invoke(null, ['']));
     }
 }

--- a/tests/ReturnTypeTest.php
+++ b/tests/ReturnTypeTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ray\MediaQuery;
 
 use phpDocumentor\Reflection\DocBlockFactory;
+use phpDocumentor\Reflection\PseudoTypes\Generic;
 use PHPUnit\Framework\TestCase;
 use Ray\MediaQuery\Entity\FakeEntity;
 use ReflectionMethod;
@@ -96,5 +97,12 @@ class ReturnTypeTest extends TestCase
         $entity = ($this->returnEntity)($method);
 
         $this->assertSame(null, $entity);
+    }
+
+    public function testEmptyGenericTypeHasNoValueType(): void
+    {
+        $method = new ReflectionMethod($this->returnEntity, 'extractValueType');
+
+        $this->assertNull($method->invoke($this->returnEntity, new Generic(null, [])));
     }
 }


### PR DESCRIPTION
## Summary
- Add tests for uncovered branch paths in `ClassesInDirectories`, `Pages`, `InsertedRow`, and `ReturnEntity`
- Add fixtures for class discovery and invalid no-class PHP input
- Preserve existing behavior while bringing branch coverage to 100%

## Validation
- `./vendor/bin/phpunit --colors=never`
- `XDEBUG_MODE=coverage php -d memory_limit=-1 ./vendor/bin/phpunit --coverage-text --path-coverage --colors=never`
  - Branches: 100.00% (323/323)
  - Lines: 100.00% (400/400)
