### PR TITLE
Add Ray.WebQuery manual to the docs site

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -82,6 +82,12 @@ home: true
   </article>
 
   <article class="card">
+    <h2>WebQuery</h2>
+    <p>Map HTTP API responses to typed, immutable domain objects using the same factory and PostFetch mechanism — the ray/web-query package.</p>
+    <p><a class="button" href="{{ '/web-query/' | relative_url }}">Open WebQuery</a></p>
+  </article>
+
+  <article class="card">
     <h2>FAQ</h2>
     <p>Answers about interface-driven SQL, result types, factories, BDR, CQRS, testing, and migration.</p>
     <p><a class="button" href="{{ '/faq/' | relative_url }}">Open FAQ</a></p>
@@ -116,6 +122,12 @@ home: true
     <h2>BDR パターン</h2>
     <p>明示的な SQL、ファクトリ、イミュータブルなドメインオブジェクトで SQL と OOP を調和させる設計ガイド。</p>
     <p><a class="button" href="{{ '/bdr-pattern/ja/' | relative_url }}">BDR パターンを読む</a></p>
+  </article>
+
+  <article class="card">
+    <h2>WebQuery</h2>
+    <p>HTTP API レスポンスを、同じファクトリと PostFetch の仕組みで型付き・イミュータブルなドメインオブジェクトにマッピング（ray/web-query パッケージ）。</p>
+    <p><a class="button" href="{{ '/web-query/ja/' | relative_url }}">WebQuery を読む</a></p>
   </article>
 
   <article class="card">

--- a/docs/web-query-ja.md
+++ b/docs/web-query-ja.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Ray.WebQuery — Web レスポンスマッピング
-description: Ray.WebQuery のマニュアル。#[WebQuery] で HTTP API レスポンスを、#[DbQuery] と同じファクトリと PostFetch の仕組みで型付き・イミュータブルなドメインオブジェクトにマッピングします。
+description: "Ray.WebQuery のマニュアル。#[WebQuery] で HTTP API レスポンスを、#[DbQuery] と同じファクトリと PostFetch の仕組みで型付き・イミュータブルなドメインオブジェクトにマッピングします。"
 lang: ja
 permalink: /web-query/ja/
 ---

--- a/docs/web-query-ja.md
+++ b/docs/web-query-ja.md
@@ -1,0 +1,211 @@
+---
+layout: default
+title: Ray.WebQuery — Web レスポンスマッピング
+description: Ray.WebQuery のマニュアル。#[WebQuery] で HTTP API レスポンスを、#[DbQuery] と同じファクトリと PostFetch の仕組みで型付き・イミュータブルなドメインオブジェクトにマッピングします。
+lang: ja
+permalink: /web-query/ja/
+---
+
+# Ray.WebQuery — Web レスポンスマッピング
+
+[English]({{ '/web-query/' | relative_url }})
+
+[Ray.WebQuery](https://github.com/ray-di/Ray.WebQuery) は [BDR パターン]({{ '/bdr-pattern/ja/' | relative_url }}) を HTTP に持ち込みます。API 呼び出しを `#[WebQuery]` を付けたインターフェースメソッドとして宣言すると、レスポンスが型付き・イミュータブルなドメインオブジェクトにマッピングされます。`#[DbQuery]` が SQL に対して提供するファクトリと `PostFetch` の仕組みを、そのまま HTTP レスポンスに適用したものです。
+
+`ray/media-query` 上に構築された別パッケージで、コア基盤（パラメータ注入、ロギングなど）は `ray/media-query` が提供します。同じ `Ray\MediaQuery` 名前空間に属するため、概念は[マニュアル]({{ '/reference/' | relative_url }})からそのまま引き継がれます。
+
+## インストール
+
+```bash
+composer require ray/web-query
+```
+
+## インターフェースの定義
+
+各メソッドに `#[WebQuery]` を付け、クエリ ID を与えます。
+
+```php
+use Ray\MediaQuery\Annotation\WebQuery;
+
+interface UserApiInterface
+{
+    #[WebQuery('user_item')]
+    public function get(string $id): array;
+}
+```
+
+## 設定ファイル
+
+`web_query.json` で、各クエリ ID を HTTP メソッドと URI テンプレートに対応づけます。
+
+```json
+{
+  "webQuery": [
+    {"id": "user_item", "method": "GET", "path": "https://{domain}/users/{id}"}
+  ]
+}
+```
+
+## モジュールの導入
+
+`MediaQueryWebModule` を `MediaQueryBaseModule` に install し、インターフェースは `Queries::fromClasses()` で登録します。
+
+```php
+use Ray\Di\Injector;
+use Ray\MediaQuery\MediaQueryBaseModule;
+use Ray\MediaQuery\MediaQueryWebModule;
+use Ray\MediaQuery\Queries;
+use Ray\MediaQuery\WebQueryConfig;
+
+$queries = Queries::fromClasses([UserApiInterface::class]);
+$config = new WebQueryConfig('web_query.json', ['domain' => 'api.example.com']);
+
+$module = new MediaQueryBaseModule($queries);
+$module->install(new MediaQueryWebModule($config));
+
+$api = (new Injector($module))->getInstance(UserApiInterface::class);
+$user = $api->get('123'); // GET https://api.example.com/users/123
+```
+
+URI テンプレート変数は、メソッド引数と `WebQueryConfig` に渡した bindings から埋められます。ここでは `{domain}` が bindings から、`{id}` が `get()` の引数から展開されます。
+
+## レスポンス型
+
+ファクトリもエンティティも使わない場合、メソッドの戻り値型が、生の HTTP レスポンスの扱い方を決めます。
+
+| 戻り値型                  | 結果                          |
+|---------------------------|-------------------------------|
+| `array`                   | JSON ボディをデコードした配列 |
+| `string`                  | 生のレスポンスボディ          |
+| PSR-7 `MessageInterface`  | HTTP メッセージオブジェクト   |
+
+## レスポンスをドメインオブジェクトにマッピングする
+
+生配列の代わりに、型付き・イミュータブルなドメインオブジェクトを返せます。`#[WebQuery]` に `factory`（および `type`）を与えます。これは `#[DbQuery]` が SQL に提供するのと同じファクトリの仕組みを、HTTP レスポンスに適用したものです。
+
+```php
+use Ray\MediaQuery\Annotation\WebQuery;
+
+interface ProductApiInterface
+{
+    #[WebQuery('product_item', type: 'row', factory: ProductFactory::class)]
+    public function get(string $id): Product;
+
+    #[WebQuery('product_list', factory: ProductFactory::class)]
+    /** @return array<Product> */
+    public function list(string $status): array;
+}
+```
+
+ファクトリは DI インジェクターで解決されるため、ドメインサービスに依存し、オブジェクト構築時に業務ロジックを適用できます。
+
+```php
+final class ProductFactory
+{
+    public function __construct(
+        private TaxCalculator $tax,
+    ) {
+    }
+
+    public function factory(string $name, int $price): Product
+    {
+        return new Product($name, $this->tax->applyTax($price));
+    }
+}
+
+final class Product
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly int $price,
+    ) {
+    }
+}
+```
+
+デコードされた JSON は、ファクトリメソッドに **名前付き引数** として渡されます。各 JSON キーは名前でパラメータに一致づけられ、未知のキーは無視され、必須引数が欠落している場合は `MissingResponseKeyException` が投げられます（media-query の位置ベースの `PDO::FETCH_FUNC` バインディングの Web 版です）。ファクトリメソッド名はデフォルトで `factory` です。
+
+### 単一オブジェクトとリスト: `type`
+
+`type` は、単一オブジェクトとリストのどちらを生成するかを選びます。
+
+| `type`       | JSON レスポンス        | 結果            |
+|--------------|------------------------|-----------------|
+| `'row'`      | オブジェクト `{...}`   | 単一オブジェクト |
+| `'row_list'` | 配列 `[{...}, {...}]`  | `array<Object>` |
+
+`type` のデフォルトは `'row_list'` です。`'row'` のメソッドでレスポンスがリストの場合は先頭要素を取り、`'row_list'` のメソッドでレスポンスが単一オブジェクトの場合は 1 要素の配列に包みます。
+
+## ファクトリなしの Entity Hydration
+
+ファクトリ **なし** で、エンティティへ直接マッピングすることもできます。戻り値型（または `@return array<Entity>` の docblock）がクラスの場合、各レスポンス行は同じ名前付き引数バインディングでエンティティのコンストラクタを通して hydrate されます。
+
+```php
+#[WebQuery('product_item', type: 'row')]
+public function get(string $id): Product; // Product::__construct で構築
+```
+
+コンストラクタを持たないクラスは `EntityWithoutConstructorException`、解決できないクラスは `InvalidWebEntityException` を投げます。
+
+## PostFetch による結果の合成
+
+取得したオブジェクトを別の型（合計、メタデータなど）にまとめたい場合は、戻り値型に `PostFetchInterface` を実装させます。静的メソッド `fromContext()` が fetch 結果を受け取り、最終的なオブジェクトを返します。ファクトリの後に実行され、設計上、依存を持ちません。
+
+media-query の `PostQueryInterface` の Web 版です。Web 呼び出しは単一の fetch であり、複数ステートメントにまたがるクエリコンテキストがないため、*PostFetch* と名付けられています。
+
+```php
+use Ray\MediaQuery\PostFetchContext;
+use Ray\MediaQuery\PostFetchInterface;
+
+final class ProductList implements PostFetchInterface
+{
+    /** @param array<Product> $items */
+    public function __construct(
+        public readonly array $items,
+        public readonly int $total,
+    ) {
+    }
+
+    public static function fromContext(PostFetchContext $context): static
+    {
+        /** @var array<Product> $items */
+        $items = is_array($context->result) ? $context->result : [];
+
+        return new self($items, count($items));
+    }
+}
+```
+
+```php
+#[WebQuery('product_list', factory: ProductFactory::class)]
+public function listAggregate(string $status): ProductList;
+```
+
+`PostFetchContext` は fetch の文脈を公開します。
+
+| プロパティ  | 型                      | 説明                                              |
+|-------------|-------------------------|---------------------------------------------------|
+| `$result`   | `mixed`                 | マッピング済みの fetch 結果（オブジェクトまたはリスト） |
+| `$query`    | `array<string, string>` | 元のメソッド引数                                  |
+| `$webQuery` | `WebQuery`              | `#[WebQuery]` アノテーション（`id`, `type`, `factory`） |
+
+## エラーハンドリング
+
+例外はすべて `Ray\MediaQuery\Exception` 名前空間にあります。
+
+| 例外                                | 発生条件                                                                            |
+|-------------------------------------|-------------------------------------------------------------------------------------|
+| `MissingResponseKeyException`       | 必須のコンストラクタ/ファクトリ引数がレスポンスに存在しない                          |
+| `InvalidWebFactoryException`        | `factory:` が呼び出し可能な静的メソッドでも DI 構築可能なクラスでもない（未定義または非 public） |
+| `InvalidWebEntityException`         | 戻り値型のエンティティクラスが見つからない                                          |
+| `EntityWithoutConstructorException` | コンストラクタを持たないクラスに対して Entity Hydration が要求された                 |
+
+## 後方互換性
+
+生レスポンスの経路は変わりません。`factory:` がなく、戻り値型が `array` / `string` / PSR-7 `MessageInterface` の場合の挙動は、通常の HTTP 呼び出しと同一です。
+
+## 関連項目
+
+- [BDR パターン実践ガイド]({{ '/bdr-pattern/ja/' | relative_url }}) — ファクトリとイミュータブルなドメインオブジェクトの背後にある設計思想。
+- [Ray.MediaQuery マニュアル]({{ '/reference/' | relative_url }}) — SQL 版（`#[DbQuery]`）、パラメータ処理、ページネーション。
+- [GitHub の Ray.WebQuery](https://github.com/ray-di/Ray.WebQuery)

--- a/docs/web-query-ja.md
+++ b/docs/web-query-ja.md
@@ -132,7 +132,7 @@ final class Product
 | `type`       | JSON レスポンス        | 結果            |
 |--------------|------------------------|-----------------|
 | `'row'`      | オブジェクト `{...}`   | 単一オブジェクト |
-| `'row_list'` | 配列 `[{...}, {...}]`  | `array<Object>` |
+| `'row_list'` | 配列 `[{...}, {...}]`  | `array<object>` |
 
 `type` のデフォルトは `'row_list'` です。`'row'` のメソッドでレスポンスがリストの場合は先頭要素を取り、`'row_list'` のメソッドでレスポンスが単一オブジェクトの場合は 1 要素の配列に包みます。
 
@@ -202,7 +202,7 @@ public function listAggregate(string $status): ProductList;
 
 ## 後方互換性
 
-生レスポンスの経路は変わりません。`factory:` がなく、戻り値型が `array` / `string` / PSR-7 `MessageInterface` の場合の挙動は、通常の HTTP 呼び出しと同一です。
+`factory:` がない場合、既存の生レスポンスの経路は変わりません。戻り値型が `array` なら JSON デコード済みのボディ、`string` なら生のボディ、PSR-7 `MessageInterface` なら HTTP メッセージが返ります。
 
 ## 関連項目
 

--- a/docs/web-query.md
+++ b/docs/web-query.md
@@ -1,0 +1,211 @@
+---
+layout: default
+title: Ray.WebQuery — Web Response Mapping
+description: "Manual for Ray.WebQuery: map HTTP API responses to typed, immutable domain objects with #[WebQuery], using the same factory and PostFetch mechanism as #[DbQuery]."
+lang: en
+permalink: /web-query/
+---
+
+# Ray.WebQuery — Web Response Mapping
+
+[日本語 (Japanese)]({{ '/web-query/ja/' | relative_url }})
+
+[Ray.WebQuery](https://github.com/ray-di/Ray.WebQuery) brings the [BDR Pattern]({{ '/bdr-pattern/' | relative_url }}) to HTTP. You declare an API call as an interface method annotated with `#[WebQuery]`, and the response is mapped to typed, immutable domain objects — through the same factory and `PostFetch` machinery that `#[DbQuery]` uses for SQL.
+
+It is a separate package built on `ray/media-query`, which provides the core infrastructure (parameter injection, logging, …). Because it lives in the same `Ray\MediaQuery` namespace, the concepts carry over directly from the [manual]({{ '/reference/' | relative_url }}).
+
+## Installation
+
+```bash
+composer require ray/web-query
+```
+
+## Define an interface
+
+Annotate each method with `#[WebQuery]`, giving it a query ID:
+
+```php
+use Ray\MediaQuery\Annotation\WebQuery;
+
+interface UserApiInterface
+{
+    #[WebQuery('user_item')]
+    public function get(string $id): array;
+}
+```
+
+## Configuration file
+
+`web_query.json` maps each query ID to an HTTP method and a URI template:
+
+```json
+{
+  "webQuery": [
+    {"id": "user_item", "method": "GET", "path": "https://{domain}/users/{id}"}
+  ]
+}
+```
+
+## Install the module
+
+`MediaQueryWebModule` is installed into `MediaQueryBaseModule`, and the interfaces are registered with `Queries::fromClasses()`:
+
+```php
+use Ray\Di\Injector;
+use Ray\MediaQuery\MediaQueryBaseModule;
+use Ray\MediaQuery\MediaQueryWebModule;
+use Ray\MediaQuery\Queries;
+use Ray\MediaQuery\WebQueryConfig;
+
+$queries = Queries::fromClasses([UserApiInterface::class]);
+$config = new WebQueryConfig('web_query.json', ['domain' => 'api.example.com']);
+
+$module = new MediaQueryBaseModule($queries);
+$module->install(new MediaQueryWebModule($config));
+
+$api = (new Injector($module))->getInstance(UserApiInterface::class);
+$user = $api->get('123'); // GET https://api.example.com/users/123
+```
+
+URI template variables are filled from the method arguments and the bindings passed to `WebQueryConfig`: here `{domain}` comes from the bindings and `{id}` from the `get()` argument.
+
+## Response types
+
+When no factory or entity is involved, the method's return type selects how the raw HTTP response is handled:
+
+| Return type              | Result                        |
+|--------------------------|-------------------------------|
+| `array`                  | JSON body decoded to an array |
+| `string`                 | Raw response body             |
+| PSR-7 `MessageInterface` | The HTTP message object       |
+
+## Mapping responses to a domain object
+
+Instead of a raw array, a method can return typed, immutable domain objects. Give `#[WebQuery]` a `factory` (and a `type`) — the same factory mechanism `#[DbQuery]` provides for SQL, applied to HTTP responses:
+
+```php
+use Ray\MediaQuery\Annotation\WebQuery;
+
+interface ProductApiInterface
+{
+    #[WebQuery('product_item', type: 'row', factory: ProductFactory::class)]
+    public function get(string $id): Product;
+
+    #[WebQuery('product_list', factory: ProductFactory::class)]
+    /** @return array<Product> */
+    public function list(string $status): array;
+}
+```
+
+The factory is resolved through the DI injector, so it can depend on domain services and apply business logic while building the object:
+
+```php
+final class ProductFactory
+{
+    public function __construct(
+        private TaxCalculator $tax,
+    ) {
+    }
+
+    public function factory(string $name, int $price): Product
+    {
+        return new Product($name, $this->tax->applyTax($price));
+    }
+}
+
+final class Product
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly int $price,
+    ) {
+    }
+}
+```
+
+The decoded JSON is passed to the factory method as **named arguments**: each JSON key is matched to a parameter by name, unknown keys are ignored, and a missing required argument throws `MissingResponseKeyException`. (This is the web counterpart of media-query's positional `PDO::FETCH_FUNC` binding.) The factory method is named `factory` by default.
+
+### Single object vs. list: `type`
+
+`type` selects whether one object or a list is produced:
+
+| `type`       | JSON response          | Result          |
+|--------------|------------------------|-----------------|
+| `'row'`      | object `{...}`         | one object      |
+| `'row_list'` | array `[{...}, {...}]` | `array<Object>` |
+
+`type` defaults to `'row_list'`. A `'row'` method whose response is a list takes the first element; a `'row_list'` method whose response is a single object wraps it into a one-element list.
+
+## Entity hydration without a factory
+
+You can map straight to an entity **without** a factory: when the return type (or the `@return array<Entity>` docblock) is a class, each response row is hydrated through the entity constructor, using the same named-argument binding.
+
+```php
+#[WebQuery('product_item', type: 'row')]
+public function get(string $id): Product; // built via Product::__construct
+```
+
+A class without a constructor throws `EntityWithoutConstructorException`, and an unresolvable class throws `InvalidWebEntityException`.
+
+## Composing results with PostFetch
+
+To wrap or aggregate the fetched objects into another type (totals, metadata, …), let the return type implement `PostFetchInterface`. Its static `fromContext()` receives the fetch result and returns the final object. It runs after the factory and carries no dependencies by design.
+
+It is the web analogue of media-query's `PostQueryInterface`, named *PostFetch* because a web call is a single fetch, with no multi-statement query context to span.
+
+```php
+use Ray\MediaQuery\PostFetchContext;
+use Ray\MediaQuery\PostFetchInterface;
+
+final class ProductList implements PostFetchInterface
+{
+    /** @param array<Product> $items */
+    public function __construct(
+        public readonly array $items,
+        public readonly int $total,
+    ) {
+    }
+
+    public static function fromContext(PostFetchContext $context): static
+    {
+        /** @var array<Product> $items */
+        $items = is_array($context->result) ? $context->result : [];
+
+        return new self($items, count($items));
+    }
+}
+```
+
+```php
+#[WebQuery('product_list', factory: ProductFactory::class)]
+public function listAggregate(string $status): ProductList;
+```
+
+`PostFetchContext` exposes the full context of the fetch:
+
+| Property    | Type                    | Description                                       |
+|-------------|-------------------------|---------------------------------------------------|
+| `$result`   | `mixed`                 | The mapped fetch result (object or list)          |
+| `$query`    | `array<string, string>` | The original method arguments                     |
+| `$webQuery` | `WebQuery`              | The `#[WebQuery]` annotation (`id`, `type`, `factory`) |
+
+## Error handling
+
+All exceptions live under `Ray\MediaQuery\Exception`:
+
+| Exception                           | Raised when                                                                                  |
+|-------------------------------------|----------------------------------------------------------------------------------------------|
+| `MissingResponseKeyException`       | A required constructor/factory parameter is absent from the response                         |
+| `InvalidWebFactoryException`        | `factory:` is neither a callable static method nor a DI-constructable class (missing or non-public) |
+| `InvalidWebEntityException`         | The return-type entity class cannot be found                                                 |
+| `EntityWithoutConstructorException` | Entity hydration is requested for a class with no constructor                                |
+
+## Backward compatibility
+
+The raw-response paths are unchanged: with no `factory:` and a return type of `array`, `string`, or PSR-7 `MessageInterface`, the behaviour is identical to a plain HTTP call.
+
+## See also
+
+- [BDR Pattern Guide]({{ '/bdr-pattern/' | relative_url }}) — the design philosophy behind the factory and immutable domain objects.
+- [Ray.MediaQuery Manual]({{ '/reference/' | relative_url }}) — the SQL counterpart (`#[DbQuery]`), parameter handling, and pagination.
+- [Ray.WebQuery on GitHub](https://github.com/ray-di/Ray.WebQuery)

--- a/docs/web-query.md
+++ b/docs/web-query.md
@@ -132,7 +132,7 @@ The decoded JSON is passed to the factory method as **named arguments**: each JS
 | `type`       | JSON response          | Result          |
 |--------------|------------------------|-----------------|
 | `'row'`      | object `{...}`         | one object      |
-| `'row_list'` | array `[{...}, {...}]` | `array<Object>` |
+| `'row_list'` | array `[{...}, {...}]` | `array<object>` |
 
 `type` defaults to `'row_list'`. A `'row'` method whose response is a list takes the first element; a `'row_list'` method whose response is a single object wraps it into a one-element list.
 
@@ -202,7 +202,7 @@ All exceptions live under `Ray\MediaQuery\Exception`:
 
 ## Backward compatibility
 
-The raw-response paths are unchanged: with no `factory:` and a return type of `array`, `string`, or PSR-7 `MessageInterface`, the behaviour is identical to a plain HTTP call.
+With no `factory:`, the existing raw-response paths are unchanged: a return type of `array` still yields the JSON-decoded body, `string` the raw body, and PSR-7 `MessageInterface` the HTTP message.
 
 ## See also
 


### PR DESCRIPTION
## Summary

Documents [Ray.WebQuery](https://github.com/ray-di/Ray.WebQuery) (`ray/web-query`) on the Ray.MediaQuery docs site. Ray.WebQuery lives in the `Ray\MediaQuery` namespace and brings the BDR factory / `PostFetch` mechanism — until now SQL-only via `#[DbQuery]` — to HTTP responses through `#[WebQuery]`.

A dedicated bilingual page is added, mirroring the existing BDR/FAQ structure, and linked from the docs index.

## Changes

- `docs/web-query.md` — English manual (`permalink: /web-query/`)
- `docs/web-query-ja.md` — Japanese manual (`permalink: /web-query/ja/`)
- `docs/index.html` — WebQuery card added to the EN and JA card sections

## Contents

Installation, interface definition, `web_query.json` config, module wiring, response types (`array` / `string` / PSR-7), domain-object mapping (DI factory + `type: 'row' | 'row_list'`), entity hydration without a factory, `PostFetch` composition, and an error-handling reference.

Signatures and exception names follow the actual `ray/web-query` source (`MissingResponseKeyException`, `InvalidWebFactoryException`, `InvalidWebEntityException`, `EntityWithoutConstructorException`).

## Verification

- ✅ `jekyll build` (4.4.1) completes with no warnings
- ✅ `/web-query/` and `/web-query/ja/` render; language switch, BDR, and reference cross-links resolve with `baseurl`
- ✅ Tables and code blocks render correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new WebQuery documentation in English and Japanese.
  * Expanded the docs index with a WebQuery card and links.
  * Documented how to map HTTP API responses to typed, immutable domain objects, including response handling options, configuration, and related usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->